### PR TITLE
feat: add available property to know when the ESP device is connected

### DIFF
--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -20,6 +20,7 @@ class ESPHomeBluetoothDevice:
         default_factory=list
     )
     loop: asyncio.AbstractEventLoop = field(default_factory=asyncio.get_running_loop)
+    available: bool = False
 
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
         """Update the BLE connection limits."""


### PR DESCRIPTION
`ESPHomeBluetoothDevice` needs to track if the ESP is connected via the api or not