### PR TITLE
fix!: move cache to device

### DIFF
--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -39,7 +39,6 @@ from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakError
 from bluetooth_data_tools import mac_to_int
 
-from .cache import ESPHomeBluetoothCache
 from .characteristic import BleakGATTCharacteristicESPHome
 from .descriptor import BleakGATTDescriptorESPHome
 from .device import ESPHomeBluetoothDevice
@@ -114,7 +113,6 @@ class ESPHomeClientData:
     """Define a class that stores client data for an esphome client."""
 
     bluetooth_device: ESPHomeBluetoothDevice
-    cache: ESPHomeBluetoothCache
     client: APIClient
     device_info: DeviceInfo
     api_version: APIVersion
@@ -148,7 +146,7 @@ class ESPHomeClient(BaseBleakClient):
         if TYPE_CHECKING:
             assert ble_device.details is not None
         self._source = ble_device.details["source"]
-        self._cache = client_data.cache
+        self._cache = client_data.bluetooth_device.cache
         self._bluetooth_device = client_data.bluetooth_device
         self._client = client_data.client
         self._is_connected = False

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 
+from .cache import ESPHomeBluetoothCache
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -22,6 +24,7 @@ class ESPHomeBluetoothDevice:
     )
     loop: asyncio.AbstractEventLoop = field(default_factory=asyncio.get_running_loop)
     available: bool = False
+    cache: ESPHomeBluetoothCache = field(default_factory=ESPHomeBluetoothCache)
 
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
         """Update the BLE connection limits."""

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -11,7 +11,6 @@ from habluetooth import (
     HaBluetoothConnector,
 )
 
-from .backend.cache import ESPHomeBluetoothCache
 from .backend.client import ESPHomeClient, ESPHomeClientData
 from .backend.device import ESPHomeBluetoothDevice
 from .backend.scanner import ESPHomeScanner
@@ -39,10 +38,7 @@ def _can_connect(bluetooth_device: ESPHomeBluetoothDevice, source: str) -> bool:
 
 
 def connect_scanner(
-    cli: APIClient,
-    device_info: DeviceInfo,
-    cache: ESPHomeBluetoothCache,
-    available: bool,
+    cli: APIClient, device_info: DeviceInfo, available: bool
 ) -> ESPHomeClientData:
     """
     Connect scanner.
@@ -76,7 +72,6 @@ def connect_scanner(
     )
     client_data = ESPHomeClientData(
         bluetooth_device=bluetooth_device,
-        cache=cache,
         client=cli,
         device_info=device_info,
         api_version=cli.api_version,

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -19,7 +19,6 @@ from bleak.exc import BleakError
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 from pytest_asyncio import fixture as aio_fixture
 
-from bleak_esphome.backend.cache import ESPHomeBluetoothCache
 from bleak_esphome.backend.client import ESPHomeClient, ESPHomeClientData
 from bleak_esphome.backend.device import ESPHomeBluetoothDevice
 from bleak_esphome.backend.scanner import ESPHomeScanner
@@ -216,7 +215,6 @@ async def client_data_fixture(mock_client: APIClient) -> ESPHomeClientData:
     connector = HaBluetoothConnector(ESPHomeClientData, ESP_MAC_ADDRESS, lambda: True)
     return ESPHomeClientData(
         bluetooth_device=ESPHomeBluetoothDevice(ESP_NAME, ESP_MAC_ADDRESS),
-        cache=ESPHomeBluetoothCache(),
         client=mock_client,
         device_info=DeviceInfo(
             mac_address=ESP_MAC_ADDRESS,


### PR DESCRIPTION
It turns out different ESP versions will resolve the handles in a different order so we can only cache per ESP device instead of using a global cache