### PR TITLE
chore: update deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,63 +2,63 @@
 
 [[package]]
 name = "aioesphomeapi"
-version = "29.3.1"
+version = "29.6.0"
 description = "Python API for interacting with ESPHome devices."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:003a96440c9d8e659b16af9a8ea6c36056bbeb6ebb3dd56333bcc211ef58f3f6"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9cc34d20d626575cca92a8954df1ffc2c9a286c8273a7b5a3a623cf3b14464a8"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e44ace2c95118c31c0939cba1213871e37b587ad859e2fa25021d0982baa44d"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:07132589c86e0ccaec5b04335e3b04627e53a3e90d4e654f154267b0d3c953af"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a4051115166d6da440f72374299733880c43cb79b28e1af528b3f997b78237c"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:77db80ee6b528e753e7eeba72ecd3cd9e852397e00739c092dc8bb7dd7b3f4d2"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4718ffe8f1bdb44a8ac6b0dc3731a70740cb78b2716abfc5a781e9e6e211621a"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:47fbd1f4b8f23376383b6a775007cff6afec1fc5222f4a689134f948c50cae57"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7b0a0c6c50c1753e239005a39d30f5449521352e579ddb002ffb221257000d10"},
-    {file = "aioesphomeapi-29.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d569a98eb6c04dc5d00a65c82f6ac10e0d45dfdd1739847bc3f33d5e19b94dd"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3fc70f239f76a131e5e988f8ea39e6287148b426ab59526550403aaa60a54532"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:107b3e65f0408cc1c491901bc3bb4ed8112a9aeab0a56261b2f9f831238c5420"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d0ba911f9b589d069842643f0adab8024d3a809589c02decb32787ad5ff6d7b"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a97018b8a771000b161b59c4112750288a7e162b99adaa0935b989e939260972"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:215f222086e772f8bd8a5aca72e85c6022d534fbbc3b01e53df87efb203a6a66"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cdb3e50901c57c852b0043f2745104f02373661571cf79819d1265ce5f56048"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7b447bd661f113d055ebcefc8d9016c7b96e45d9710224141000db5e42089fcd"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2be2f641334250046512f77f9cf1a40ba5885c6f6750e7063dd9497644bdcce2"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:68c676e67b9b2a37f825b4f72c7f82fbdbc83de4253b06bf44c63aaf3b00cee0"},
-    {file = "aioesphomeapi-29.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ee2a9fa7dd77b3a946faf764a57c880725b2d786bf43f5762716bea3e8351798"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d2cfe053d3824efe239f4f9f5101a8b6a2c7ba4eb48f2fe7b58e63a9612dd8b"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:edd028ffb44c6e92eecb9269147266d2637dff915e4513083c9d4e742b2a3cf3"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e3e5b76ed0b4119bb988b0aafcf1894e93b0d59dfa28d2eb8bf3ea3c93a89ad"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:108ef05232d955eaa142f60dda88928fb7c9192f643ef09a4deafdb3f0b58730"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1e3520e2c114a4c6ecc32c150061e9a4e63edb0258789f7cdae555e8362bea"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ce0de2ca87ff8a27622f4e5497ede03d03954da2a935e5db00b1b38c4763704"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3398478d1f629c9bf702e3f394c5513ff43876115a2d82277c721efc1e586bf0"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8e1b47a36abea7727b782df0303a5192ea73702faad7fafc3bbd87b38a6973ca"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ac78e726ff6c6a0dcdb9ee8bfea9a2f8cff3adcc651f7663820df8a50b5de75d"},
-    {file = "aioesphomeapi-29.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b64827f8f2f6a689182263f6001863e1d2a71982351861535c6124f4244c74f7"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:88d538c1408c199a0c55202cf6ef516008a28d75ade8998bbd3c89ab1f4e3c07"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9496a49eda21d2bd2ca233c7e8f72d82220ba2d69d26dc1a423543989a1b9ce7"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a2651fa08c6dda95b7be759216ff35bb8e03b3603ca85d5cc280fd8444f7b2c"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:90730bc9fd665383f52524042d0d7da94eaf2f6a52fb36f85f5e1b9198026319"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ef15201827804018ceba36cdf80b256b20a6c3beafc74057fe8f18a0c52692a"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a748b717535ad2f09c06ef4fd8b56b8fce4963b537b1d615b2b173dd4161f81d"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:088e6dad7eca3d9906c5bf03388e11a2a8fcc16c4aaad2d4efd9264a4b86f2ff"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:624a7833a473b8923b1cf6f8ceaf550350c7e6983c357caa205f69604a78fe39"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a65d33a62db67e8b4dfe8cd4648f7331e309bddca53813bc39b7473c96c9e1b5"},
-    {file = "aioesphomeapi-29.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a471bce6293a94606c3e0ff1121c16b2a3d2dcd39483d14de661807f00dc9d45"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4bc3d4557fb425a809ef1a5a9103eb02612b7eb3fdcf88b9bb192b781f917f0f"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2246d9983c00716a4f33783a8480a5b02fc5f8d511df9573a7e577b214c38bf8"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36052ff5c3d488c6027bb0c2e52ffa589233e86caecced44219f530baac7271e"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b72396631b8ea6dcfbc267d469c6aece16604830ab7747037e6366e2a1856e36"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5e0b7d8064bd29353238743c991d4cd5816f577f9e5dadceb44d1edad0cd0da"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58b813aaeeeeeffd677b9f0cef9da9ccf65a20579b6be93ec09a66579393642e"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1dab46030eb0c23e0ad9ab906b3ac545354c2a0ce8cd5ed1e5417d42d9db61b5"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:3889b6444d2d0296df6530b10075eac57c8ae3db36b4a4fd962fd9bd9755c213"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:21021827ce93dcdcca899c143d68413bf77ef26d0068b4b6340b6b3a80824650"},
-    {file = "aioesphomeapi-29.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9f99ad5dd41996519da609533367cf1d14a56458540b6b033acdc59da64c9c58"},
-    {file = "aioesphomeapi-29.3.1.tar.gz", hash = "sha256:2d6693eb78a1674f4fbbc0446becbe87e21328333f9c98b106ee88e0d4eb2cbf"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:44300cc2a3b869beb7ed15f1b41af346294c46e3cd6d5d8f65f3f4608a1a4a71"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e95388dc665908966c3e0bc83a3637f29a50fafb5ae10ed1d6ddbb7011503c50"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:576fe300ff2ac65007aa8b16405f7c8bc1dee2b9effe3aa32a91cdbf5a16a37b"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:44423fc5425915dcffa1e4eb73cb485ef9f67a49bb4b81a23eb4602d02ebb427"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc51e4f18f674a46106941c805e672d7cea68845dc2bc93ad569ab720465ed50"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bab7cfb228da703f11d648db315157ceba1faa841d7a0d59fef03bbafdf828d4"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9d8a2237ed703e6bf6aa3a180cac3464a9e612f881fa76a1978d540211e37bb"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b8a536865082eb2ead617b30a72aae4892956f60fda7c517d4794dce0962b4b4"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7984034b212eb06f8d704e87d86e5829f777dbf0fdf99face47591a8fe45a232"},
+    {file = "aioesphomeapi-29.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:779043117d019b89a89bccfc2abe2ad1ab7415cbcb51e66c02e211b06434189e"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b9fb4c920f23354502ffdc3d65349b039dddba8e9ddba0987579a665992f5264"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:33c77532b6c88a0fdd66384b43e3653bc252b6d15b621b198cfa817984b24822"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d5da44cfdaceb06e1af921ceea9e5b4283514dc99a256d4da3c9dd3441285b4"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:19c233dbd72c5a3a9af1b6a63a482f2786abe0e8c3c4cf97275c8628b288b8f8"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0abc37d48110275904f8a51fd4cdadf41363243d3a23102079d3df91c75c25e"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:baec1d0e9feff59d3b6c96a5326fd655011bd7c1225a2825840fe6ff10d27333"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fde94773b82ab076dfb067ef096d93b0fb6884b29a85312b73c32af5c7a2e55c"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:72efdd4d6939e01fb85fb297dee27d759c07be8508a2d9a5c312606a61c6e851"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0e6ee0a4f71c04eaf6fa91e826b066d521760aacbdb311d107aa75ce07788c86"},
+    {file = "aioesphomeapi-29.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33a328b2670c35b203eb07605349e18668b0fe0ad225d7b844a83e62f5316b6f"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e676be4e265b52bef7699e1b31860e981602b13629b25057407565cd23a5dfd0"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fca7edc39cf9abdcd1c048296fdcf4b31bdc764f6d120151a1e316ec320f698"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f901f0109c5844be30bcf4728c20774821c134fc26d92ff1f742bdd0f6be001e"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ddfa87608231300d3105224c25d86feb7c29fdb432fed78251313dc453a0221e"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0884538f6af410df7693d253ee32051c1cd39516e6f3735b4e7ad26257b2e58c"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:142d79b00f13f9d7c8986fa6a0b1f202fc4b8b0a43c473f0a9826cbc8d92a194"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:15d5765cffef449880b0f2099edb9e160f87fe04fe7b3df21a964310314a3080"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:809d55fc2b358aedf3d68958520a2de5e4f970bf0ba4468233de4e492d4dc592"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7fc6a8a54aeff5d6016a31bef9c9bd8a21e699335db8657f706b4a2ecc433550"},
+    {file = "aioesphomeapi-29.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03e0bd7b75728c08629e9c69dfaf0545351e1be6458fc97721bd06b4963c8628"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:223ece27f89dcd1cc8d16eaad80809854a005c794e72ed8134a2337a71e7fe0e"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2c695eb931955e4371c71cbdb8d09084b5e4df16f9d0509c3021301cb480d438"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:865cbc8c50fad493ca5e294eadc779d8fa48a6e67ed7891a05aad3e2bb1d12e8"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ecd0d702b13836ea8a5dc9ec0f44e9dfa88662db1121cd15c1fdceb513b700f8"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:356ee76f264fa0cc803e39edc89a3596b6f000cea27778807c47592a52929cfd"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a422277e2468e48499b86047b1a9c88911e025e5c29df0128fdec940cdd934c6"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7cdba5c89543da5a711486a097a4bff8d35309470bebdfb46e51837d80e97d41"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3ac3096a3665f6a1a8899ac0931f133262b8b228ac77538bd0bdaf414ec5398f"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b6412a685dad689c404a2023af27da2d7510f292cd51e10057f4e238af8050b5"},
+    {file = "aioesphomeapi-29.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b2a593ec3b0d1a071826f6c7b959c9a13f05e9e7ca6687bc00fdcc8a3b856fbc"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e4059def1389f76e305dfa9ae406ef3ae2c5e452e3da53ead8e9866a42970f90"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:37a89bb2e056d1e30da7dc747fa001db86a66248f33b13bc0432d22739802324"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bfbba46bfb8295f93f24917318e4bb21cf15ef4133f495e79c38e81bfa2623d"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c8252812fd611d7a2e2931ff928b9968a5e00643f05c4660b0b3a4b48e6d1c7a"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d7315a7d0bb7139a0de3943a5728b711f18c85a06b60147e79e9b3f93e39e03"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84fa8bde9add9b03120574eae6e5e35e585810c1235482d825913051023f663e"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c9c824c0644215f113fc275452f7139e32b2dca432109764c36d16860f6a5a0b"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:6c5ab0477e87e5d2cca14a0b6a3f37fd7cd7dab6dbfd4d5478027be38b9bbc8a"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9dcb1d1b80f590eec6a6cb931f81d2dcfa5a936e5b1ea68f59dd73e49dea7972"},
+    {file = "aioesphomeapi-29.6.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:271fee10b79bfd26254a28e8b4db65feef42237cfcbdbf5bf5210eac8017eddf"},
+    {file = "aioesphomeapi-29.6.0.tar.gz", hash = "sha256:5e5fb17ad505508f25f4a64134b14641d14adebc4066595a19184c4382310288"},
 ]
 
 [package.dependencies]
@@ -72,14 +72,14 @@ zeroconf = ">=0.143.0,<1.0"
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.4.6"
+version = "2.6.1"
 description = "Happy Eyeballs for asyncio"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aiohappyeyeballs-2.4.6-py3-none-any.whl", hash = "sha256:147ec992cf873d74f5062644332c539fcd42956dc69453fe5204195e560517e1"},
-    {file = "aiohappyeyeballs-2.4.6.tar.gz", hash = "sha256:9b05052f9042985d32ecbe4b59a77ae19c006a78f1344d7fdad69d28ded3d0b0"},
+    {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
+    {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
 ]
 
 [[package]]
@@ -291,55 +291,62 @@ docs = ["Sphinx (>=5,<8)", "myst-parser (>=0.18,<3.1)", "sphinx-rtd-theme (>=1,<
 
 [[package]]
 name = "bluetooth-data-tools"
-version = "1.23.4"
+version = "1.26.0"
 description = "Tools for converting bluetooth data and packets"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9cfaf86fc5f0bc5c528ec039f92eebb2ddaefb528624edb140de0a3ffc67044e"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:455992013e6873af3059d1ea6a0745bd7cdbc7ca3275a2f6969c4b2a53a44ac7"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7127c6c17c1129d7e5ecd76e5d815a06a7fe1917c980725ff3e91b27bb7dba0e"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a7ed26e6c508aad224af2affab95fdec5a36b664e092d6b83a538a58a2168f8"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6d9583da68422259e937bf1bf5f1141e6ad9a9d0e0bd0ad4636636ef3f66f7ce"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:728b05e4ba48282f59ed279fd3a3671921d3f0c48989c50e1980e2037955a344"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3e02cbfe49b14e57f121f83fb69dcd1deb1c34c9ddc60c901eb3d48fc5b1a37e"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-win32.whl", hash = "sha256:533f64c919d731d1d5bd49e4d09e503eb7d7e229dbbefac6bd2039736970aa13"},
-    {file = "bluetooth_data_tools-1.23.4-cp310-cp310-win_amd64.whl", hash = "sha256:1421ac0463e1a2bd87496f9d8a45f1a7f5a43da3ad6ee9ac72d6ac51df98e11d"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec5ec48c9e7e6b885d2cc9784cd5a8006e1e92d51fbc36bb715f8dcbea76c6da"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47e9a37173efc399e2640f8d0964bc2ac9815e2004a9d753e03693061539c463"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6dfb59e5fde2fe5929590ab719eb98b5389e958610d3cd240820d19923207389"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06d2f123519ae0b820a0dafaf1f48b1974f6f37790317419050c32d7e44a73de"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c50d985420b0c96664064c6b5ea5702dddec6bd48d89b8d1ecbe0ddf128e141"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e675eeca03bc53f0853e26914d26b1ffaa9e3643e67f458241c108eed9f54347"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c28badc63c6e33300a0e7fdf0991c13d92bce6d4e6ac8a431997efc525d38f86"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-win32.whl", hash = "sha256:e98966f48687c18f0256b28e2aef353a2a714ecc88fa30fed9931b5053035e00"},
-    {file = "bluetooth_data_tools-1.23.4-cp311-cp311-win_amd64.whl", hash = "sha256:2a1377bef3158ece45bc150790da9a49c3c1fbc4e89a8e5c4400472ac0a6425f"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5d3dd7be854ae1c11aa719af3e3234d64a549d0e815f5d4d0ced0241bfb96ae5"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47a1e9c4144e330daaf1680fe28f4fb97c1c75db59d31c96a497ce8d9e2c1ac6"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c52684d70a0b58069f9e556ff71c333693879b7d8b26c792417e4563fd3d801"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3813a0a6e1ed49ef071be924b5b351b7394f67bff55e5d96abca357807f12c47"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2131b2a409bb41269aef525673617371848ed22675daa80f3e2d87f656eba32e"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:92e98ee06c7b3fabade6a3d7cc78c4fbecf93d68150795b679717b0b14a92136"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8665ec807b368787f7febcbc4fd6d8b076a2de58bf4cda879cf3ca96d418e987"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-win32.whl", hash = "sha256:c0502f69149aa03bf0ca9cc2a21623711379bab3f4d9fa887679b3f38a3bbf13"},
-    {file = "bluetooth_data_tools-1.23.4-cp312-cp312-win_amd64.whl", hash = "sha256:0543f3867456965b170aa2c17faa5108386323a9df054a48348496ec495cf6c6"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3215d7c434f7e14a78c923f5a480ef4f881494ff3aa09c011c9f15c88113c2d"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05e1105bb950d729c682dbd2b9dd23502a3155eadc6407771c7c8b78a434d075"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:afc08bbd8e3a65c94f18fa3812a9caa90ebb5eefef5643fea5ea8c6ff8daaec6"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7898f09bcba70d8fc1502ffdbc737ce817dbe25dac6fee59bed4b250388e3f76"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:2f4f4c26a5582d36fd06fb307aa1b07572c74ad538121586a4c1a73e1c134c07"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:611a4b7c58dc913fed588d2bd871c21192a40ccaea0039555f96b7f5efd4ed9a"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:28cc05a812828cc727cbb567d67f7148fc40f5bb9fe7462a792e365c74e850fb"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a07d9c999d24973cabec6bfd3236035eefbfa752850220c231db5e86357714a"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-win32.whl", hash = "sha256:de26a1d58f9cb7d58f618fafcecd092292d45690bfa56232b2ae8139530b1bf4"},
-    {file = "bluetooth_data_tools-1.23.4-cp313-cp313-win_amd64.whl", hash = "sha256:a6fc4b5ff5af6dec3e1c555b232740ced5aba5f4093a92889f34c1b397a9d20b"},
-    {file = "bluetooth_data_tools-1.23.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:98ce1a5a38709064fb73f146e6d69d60004e0c00f0df79de19137e02c658a087"},
-    {file = "bluetooth_data_tools-1.23.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cbf90b4131e45bec5c995e3f1c3482a4d5cee45c060e2e908f1787dad1d3e4d"},
-    {file = "bluetooth_data_tools-1.23.4-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6bf47e9f790f1f131e3c9c96316e7a75d1d13dc1207a02d56fed2070e452c480"},
-    {file = "bluetooth_data_tools-1.23.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d59bbd90181244bb220d3b4c95a1456b36d694ab397d2fa05cef8e42207c260"},
-    {file = "bluetooth_data_tools-1.23.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:206ad444077eec9fa4297f9aad3c30e6503f9ed46d4b085348db3f62fa161b99"},
-    {file = "bluetooth_data_tools-1.23.4.tar.gz", hash = "sha256:e5495fed2ea741de6144951012b48e5fcc43b766b1b3d865fe30758f08936ef1"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:236512c00704f6d946cf79a4b4ec7dbe20aeb998f77f9435f6259d6d4b19f63b"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a396c056c66f5fc456485d6fb08b872751154545724583263242b5881da5292d"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12e8f00d5486969fb859a18a0e464044888d4ea0bc8e691d4482019d36f7f90c"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94f8e7687fc072c462a04271e729f51d16b445f859342a5a90fa67a847a3561b"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25da202f13329cefc9b1d98f21931fced7f1b7b7267b7b0b3a49a1742d9c8f72"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1444205b9d64db24f19758db314282ce53e6b096764315141ec58e05b3c81899"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:99825982747624353661e88cbb854712ef14e95aa2ed79fc783cb3e24668eeba"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:fb38db678e25670ace8db879466467eeacfc968a6f854f18908f618a319d5326"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:2273cda7f270c1d8e631d0e7478348bee6c53bada2d5cafb5c11831b81dc120c"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:05dbc2ef819950737454006cc9ec58658d4ed319cc9e6aab437f251bfe9a1116"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-win32.whl", hash = "sha256:1b2316dc709aa2b1b2982b28e482e2cb9bc1009eaaf2471d14dc4e3f76168e7b"},
+    {file = "bluetooth_data_tools-1.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:c469e7b3d4e0c5d9326e75f84d6026288fdfac454d9a1badee5aefe43909c3dc"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:447a2efc42e239040cf4b3f87221ad445c89e749f9a2295806afbaf96a79e2ea"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:305d2c181aa2c66d711822c9137b9bf23f10118f70d75041ab14cdd761f58380"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff28e1e15595778dda2abce18e1212b8f3434363b0d329b602ea99f5a3b2a4bd"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8dfe4a798bfdd8fc72421c7e2204551c9a2b8c1844e071ee45fa2e19d72ce99c"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b51b613021f64223bf870169d37012274de7f24372779307084518bcd408486"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:85264d166ae39c105fbb7d91758d3c10b5aeee41284a510a068e9143f8732e76"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cdb5a30a9539024c5b9c134955e6d7078406bfc7097b98172a1bbe84f3c6126a"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6c3b4a81461e85f5831d04e02410a71434f7633a92aeedd1c80555b151003077"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4a37bed54f544fa992e38fb421bec49bc10058786b8c40cadaf4a6a1ab4d3d2c"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b7e15f6dd8d712317a7d541fbeaf29d3304f6cd63f02b721c67e990d303db880"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-win32.whl", hash = "sha256:feb5337a38eab9d96b9a4c8eea31abfb8d2f04d8f8d6a047b1dcd2fb31e0fe94"},
+    {file = "bluetooth_data_tools-1.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:d179442356a3e102dd1a632b5ebe03ec1ee53d1b20ffdd1ac1d660c2f00bbd36"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ecd6db3655e2b5a5ac58455f0d663d791f9f11e69949993a9b63f71ba66d98c"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f11b3e6a6643740101a0be768b43a2bc4f5cd494da8610e74f887c3f3715a5f2"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:874bb032faf6ffed7a2b407909adfb9a33b1605e6173fc202308eb1ebf42cd14"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4412ef0549cd129d08f665d11c19741637c189cffba1b17f06cebbf9a5f40ece"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92218446f434d4c58a4097954907142cc39cc38ae0af78ba10bd7d1646ff96ec"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4eb1270e018a961f6cea9f3a548e940dcf3c9c92cda84045ac1f6f09626648a"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9491a68f25d80daa7b61af97db13348d54bcad40bee09d8c2da1c2f87899e026"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b2ccf76f089372951c1d9ea5dac9346b922b9d1d235225415a13b16f14d2e08d"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:100c9402963de67a6ec291c760f1e35e7e9d297092a11dc3c6a5115595dc3104"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a3b87c13f0dadbe9c5921f91003486e8ec439da5481597415a54d6e4ce524bf3"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-win32.whl", hash = "sha256:7c5bb201cdd586469844657e0da620a721e38204eff91f96dc67dcada6bca85c"},
+    {file = "bluetooth_data_tools-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:3a2ece43e98fbfd68df9e5a8d3f9b6160191d44f966a70ad0b9a52d7383ab632"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b279b49b5e864cb889520aa65bedfd2bc16349ce4374c2f53e5772fb4bba1c6"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae3d6e02230b0385823461321b9f7f83857f618249eb9b058b96b0e48ce385b1"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce1ebc7c5f349705d504549fcff5e3ee94f2d7b053b21a9496100c42d6b5a741"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51e3acc09bacea9bee53f1e3cb382271dbe091535208736d457c5d9efd886a5f"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28d1309ff975d78ab523f67c5d79a12059278f0acc4dedee357f585f0c15cfb3"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a023693c15df01d513f029e6be198799c82a568b14a9c2369e60eceec10e8d1f"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:741928112b113a358935edfa9cbf583777549823c596ae46834f56b4e86a57f7"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d4db5554cd55dd86adfc9577563cc73a872e834cdf4a7714a2e3716fec1096a6"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ad4c1f99a611b424ee69260de8954a20ef833c64c6820e847d6d469c545faa52"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:474157324b475a671843297494b6b6e6c89ece8d0c42b9e3f46c207e2e6cb4b3"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1d4bcd1e41e59fd9680e67d6e628bf76cda84f3e29345cf96e8b919b7e5cfda6"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-win32.whl", hash = "sha256:54366ef70529e69972a8a2786425a64bb5343530fb8691ef49a65b2af023729a"},
+    {file = "bluetooth_data_tools-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:dbdaaca4ebc5742dd8a073b278532f1c87e2990526f1766282575a7aa29f7291"},
+    {file = "bluetooth_data_tools-1.26.0.tar.gz", hash = "sha256:bbdb244a9dc5baad453175cc783063d7f3c63697ee3e8cd42fd3ee79f97319fd"},
 ]
 
 [package.dependencies]
@@ -682,43 +689,47 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "44.0.1"
+version = "44.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["main"]
 files = [
-    {file = "cryptography-44.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0"},
-    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf"},
-    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864"},
-    {file = "cryptography-44.0.1-cp37-abi3-win32.whl", hash = "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a"},
-    {file = "cryptography-44.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"},
-    {file = "cryptography-44.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41"},
-    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b"},
-    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7"},
-    {file = "cryptography-44.0.1-cp39-abi3-win32.whl", hash = "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9"},
-    {file = "cryptography-44.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7"},
-    {file = "cryptography-44.0.1.tar.gz", hash = "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14"},
+    {file = "cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7"},
+    {file = "cryptography-44.0.2-cp37-abi3-win32.whl", hash = "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79"},
+    {file = "cryptography-44.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa"},
+    {file = "cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4"},
+    {file = "cryptography-44.0.2-cp39-abi3-win32.whl", hash = "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5"},
+    {file = "cryptography-44.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:af4ff3e388f2fa7bff9f7f2b31b87d5651c45731d3e8cfa0944be43dff5cfbdb"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0529b1d5a0105dd3731fa65680b45ce49da4d8115ea76e9da77a875396727b41"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7ca25849404be2f8e4b3c59483d9d3c51298a22c1c61a0e84415104dacaf5562"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:268e4e9b177c76d569e8a145a6939eca9a5fec658c932348598818acf31ae9a5"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9eb9d22b0a5d8fd9925a7764a054dca914000607dff201a24c791ff5c799e1fa"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2bf7bf75f7df9715f810d1b038870309342bff3069c5bd8c6b96128cb158668d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96e7a5e9d6e71f9f4fca8eebfd603f8e86c5225bb18eb621b2c1e50b290a9471"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d1b3031093a366ac767b3feb8bcddb596671b3aaff82d4050f984da0c248b615"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:04abd71114848aa25edb28e225ab5f268096f44cf0127f3d36975bdf1bdf3390"},
+    {file = "cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0"},
 ]
 
 [package.dependencies]
@@ -731,63 +742,63 @@ nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==44.0.1)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
-version = "2.34.0"
+version = "2.39.3"
 description = "A faster version of dbus-next"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 markers = "platform_system == \"Linux\""
 files = [
-    {file = "dbus_fast-2.34.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:79f4db43746f78b65cc8fd32d2cf0f3b9751387b12ba6386c3e45dc908628518"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc40230797a053bd151010c28fdfc785b92f5278d30b90aa246d7e8c353a66b8"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:a928e35190fb2e73bc024f502e4a070f0b2b562069d8643728f6be7319e38d49"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:448c349b9eb69a4aaec375ae6f3518bd890bd037652736e00df499cbf8bd120e"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed2dab8b4966e7ef63e6561b4cb876ca88aa80c2d56c55fa9968baa93f552e6a"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:42d80d633b299ffdf796633ad053e786ff801e2c3f4a5313a84aa7f2055fa6a7"},
-    {file = "dbus_fast-2.34.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:815f4eff740bd7d8e48c99764aeeb26d677efc3f2ffb940fe3900690eeab2f09"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c184e376ab13d07545f805f04ad89b6448f1c79e601f6d50c9afb5533e574f96"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83bc3114c05892dbed455e1f60b3db72b41d148b5a80ad4ff631a29ef39f00c0"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:da2c434db31f6d8ca8b85ef9675f59ca21a0a04ecded92d734c34323fcf8e9af"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a3d0347f62f479a3a18fbc754f716e9c22d9c605d1117dc5847701c00e96ecb"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:660710b5576845cfa0dfe57945982d7613842130b7b2ab7c9c30946d5af7742f"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:31e7f5e987ebbb4454ec8fd1f2da30e5c5e3824bf3349902d8a1673af5d89322"},
-    {file = "dbus_fast-2.34.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:30e400afb0e76d4d1331c4ed094e2f1083665798b1be1185fe4ef1b512b2f279"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d2216262c5af08ca6ae55b5ada9f2324e598494fbf79caea47a8270ac6c3a258"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e4a3b3bf7abc78885a838850147d0f7faee815679cfa116f981df7bb0376ed6"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f7ff4725e4f42cb78d6fabde939ee298e0f02ce88eef6278e93175399752b5cf"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f793c638181bafc9bf4d5414d951b902898dff90aebed0be9fe738c47c147e"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:18fb0033e201acc45c21289d26af0c1f653439619327eda68261199840630336"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:15825368b033a0588095fbd5f400b7ea76a4350a925b620b25aadeaf31b6c963"},
-    {file = "dbus_fast-2.34.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d0360004e7f3ecd72216b4bfd23dbb0b0b2669a61109b79bc7810032e6f4d0"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:03805bc865f83c312603ef08e9f39ca32e0a2ecd547533874b606481452f6a62"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97a6f5c0b0faf1ba33ca965598842d6dca546f1772ac984597db55ce7c3df877"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b77aa52a60dfdb8e9bf71acc60ee130f0f8b46245b4af2b52cb1854fd0a4cfc6"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7404fa0b8da448826ef902147b0a2bb5639de8414581e5eecbc141734f05af8f"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:8656a01c0afce62179b6a5c7d81317266fdb79353e38d0e0ae5d47a41d79ea39"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:283688903a351fe62498de77dea8606668c2047b60e2f8c46ce3d5166fe9a228"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6605e75cbfd0acf55bff1d8226b1232aed50981f11fda07ff0d9b63ae7c2b8ae"},
-    {file = "dbus_fast-2.34.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b03f9ba02707d27f6a93062b7d414106c2d9308e332d0c813f219aeb01f4b116"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b062933ffb4682d7eaec32769903449db9d725ea2b30a7d7b2e4799e77cc5dec"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ca3718c397c41a0df97cf83d6693096567148f63e0b4e7a3e1ccf771ed2afa"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:685dc7eafea2b9f6ebc91120d2877aeed61c881be27045c73d790f1cad99d5f7"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d3871301ea1c052b3ba588da089e130908b6b1ec9a70a3b84a7458905f07b19"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f7d00050870da39788f584474007a9b4e58da74b42a3bc7760fadffb2b983a86"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d54554ff9ce5ce5a50c446f559aa4af742f98ac35c2062976cf551802b8f5409"},
-    {file = "dbus_fast-2.34.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:62ed9ad1779ae2f765305f373eed0b8576535b6141d7e1a3e726dbe006f98da2"},
-    {file = "dbus_fast-2.34.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:78cb42c15f4a5e71a930e54ad12b17d61922bcb3b4dada8753baf09e5e632f68"},
-    {file = "dbus_fast-2.34.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ce7e32b7f3c55b32b2d952cff05e072b272ca2d5dce6fd5e17acdd9656234dd"},
-    {file = "dbus_fast-2.34.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b7cbeeb606ad4964e57c469ae5aeda7a9ab85bec2282b19decf984127167f5ec"},
-    {file = "dbus_fast-2.34.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:723d2a9295ddd1f39c8544138a5951fa0c75894b5ea03c8979897e145535c529"},
-    {file = "dbus_fast-2.34.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:64431fb0c1dacac36132c46031c227774ed1491cb386554c941c5e84e4366ba0"},
-    {file = "dbus_fast-2.34.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dca4f301f095b5b0087cb6ba7f18f87e84d182845d606ff759dba441f11c8f00"},
-    {file = "dbus_fast-2.34.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f80603cf4f9964d2b72463554427c82e649a64b3542a7d78a402a6ff59391598"},
-    {file = "dbus_fast-2.34.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:783deb17c112ad7e3e684f061e5fcf626c0cf8c1758a2b168b84ce6836374e78"},
-    {file = "dbus_fast-2.34.0.tar.gz", hash = "sha256:32aa03b4b102e7ad8caf39c708e3c263ef73121a4bb64f3f877c5cf0bad91e45"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dcd63087e710c4de2a053401999a2bdadfa6afcd9996c7ad8f86648278e4ca14"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb861e822c8060c7068df51fad38a0cb92814dfaf4b4b35f8bee189d5d50c462"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:142e3d5c29547619bafdc15c5f691040b58e726aeb851c8baf051c92c0cf8033"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa95668f1504b6c7745448f6ad3e467c0c1fac3b7e09b7b9502384d6b1070202"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a27ea12d08854323ab5b570abe01e032a16ab8518d29a76de72485bf7304cfaa"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7b940d2d29fe32a17e66c32193628aa4cffd7302d8a38b13a634d7da21880436"},
+    {file = "dbus_fast-2.39.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2cf62b499c3237028497c9b03d9b8da17c9b39744f417f4abf31c044e5a90bed"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:18ec63ca93b9fc7be1b2cecb2fc38e02f3684d3584754b8f56c0ee7db7759a84"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c3fe83f1cc152beb6834fd10ccde226d10466d2a790079227c03d1f36c0076"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f629abe042da5158dba440f71424f9e2ad5524cd21811c172290ba1545864382"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1b8af87c663fd7ee11f1da30d320c2a3316f9dda08dd683ee54ae5e2584275"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2f1a94121536b7fc15ccdcbc180191899016181c10bd886bb928ae97e8a05c8f"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2bf7370914c4190f3cd06f169d49ab48d96d7fc59ea9fa68074671a974ec4307"},
+    {file = "dbus_fast-2.39.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:23d89b4b76636533496a83bf77db8204ef06ce9f44148687285b6f02cd8e0db3"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06e12f638d826e1f7a5a66c866393bcc1b3bdc6a112503d44b5041491e4c1393"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c45d9860e9784765571583285940175d202880dd2ffef92dddc99c0fd7e3d356"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:68865ae79e9fab39ef2223d39cb405b697bce79960d7292b244e72ec4e3457dd"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f350603db681afb8351d35c872960f2e4442b47fc90f16c92959146649d810b"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a084100e335e35fcbd20e7a5d60815709c2572d3db22c8864b614a9f80399465"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8a72d345138bd2fa32d0e8bdd1b9a1711f8d2c131020212f0a2031584688e6b"},
+    {file = "dbus_fast-2.39.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:410e852106c338e0b5a328a122cdb537d6c34498da4bae6414324b07fc66e63b"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bbd68585f1251bf109a0a1c539a6fbf567c9bd5ba8bd07a420458e22092638a5"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:467f819cd572df418350918ad7d697c6a2875529fa6ca03f2e5d48cb3d3391cd"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f5c967e4910ba2ff6a1cd0a9f490a88edab2b206930491129a3ca5f74cc87cc9"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2605793983eb2e1adf9ccbc0854ffa76a7bc269907f02eec828c972cabc5dde"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:2f2c78cd5e2b472ff1c10aae3f4fd0121d30570f26a80abf4fbf9c0720bd4ca7"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f3cc0f4ff6f834a0f11038728c22cbe7cca83e9518529a2d9f0c25ff71af608f"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8260973c5c5a0de51e408ac5f6b18e098b891e1257c4c91f73bd4a261e3b2796"},
+    {file = "dbus_fast-2.39.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:065564c693d2a9dacca456c85d4bfc3622c43b0a54ff22f6ac9d9f525fe0ae58"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5c7c938b790c335ba105bffafd4ef14c5657575bfa093f27c7de0f16d384fa58"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98d074af3bb18454536639fc22a66e1411a923a6a0f465d1c1f3aa35029064ef"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:544b74deb487ee4e91beecae7a07b7578ef90695ff72fc1453589916abcf6851"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c753198e7c5b6dde4c97e9328c90a70536377c578d37160f96bac5d7c4c4b15"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:056cf86dfb8d18866ee4f864b7ed3e67c537e6b19e65ac698ef7b38df0684624"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:49344035f495f6d19acb2e69445eacb8fec5ab92f42831c03fcc5dfa1792c693"},
+    {file = "dbus_fast-2.39.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:19b552420eb4809a4e27d8ba918f0fac3e4b7e7c6fe2b4590521caf2df2dd2ce"},
+    {file = "dbus_fast-2.39.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cad104259782802393c6e208487ead067315be5b03465bd6a7d6226ba283f68"},
+    {file = "dbus_fast-2.39.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef730d836eaed02e4f28df922cec0a105a05012e4e700cf52a76ca55480d5f22"},
+    {file = "dbus_fast-2.39.3-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:92e399ae6e5163bc141d030e1732e7bab1dfdc394a30d8cd3534c037a0e9fb5b"},
+    {file = "dbus_fast-2.39.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f46f326352e1b1dd7a469a988fa483b16095420cf75e01722c83b000bcd2eeb"},
+    {file = "dbus_fast-2.39.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e99970b1749d5aa534771e5ab2c773282c2be421e0d9e35d98e82bfb9eb48c75"},
+    {file = "dbus_fast-2.39.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:060a3ee51328d657786ab8faea6cbd0ea0cdbd19edd0e46973bea5fdc3aa4ad0"},
+    {file = "dbus_fast-2.39.3-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:dd131abd033ad3787b21b67efc46ef9b07363f1e77e56ffe4c28309232b872b7"},
+    {file = "dbus_fast-2.39.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b08dc1a3d43446788c25aea1c349e1a0dd2e2156b5de7f85d006b1ebd5f4a73"},
+    {file = "dbus_fast-2.39.3.tar.gz", hash = "sha256:84b4ff23bcadfa794842e8d3eccb521907f7c6cb8d6534c895995840306512aa"},
 ]
 
 [[package]]
@@ -834,14 +845,50 @@ files = [
 
 [[package]]
 name = "habluetooth"
-version = "3.24.1"
+version = "3.25.0"
 description = "High availability Bluetooth"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "habluetooth-3.24.1-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:db88466c8aa52596a98fd02c8b91ffde88a640026b8eec7dc6c18a6b549cd94c"},
-    {file = "habluetooth-3.24.1.tar.gz", hash = "sha256:a459c41a410458f3655837f63001e1f39c482f336834bd0d5f82f5f1f2a17389"},
+    {file = "habluetooth-3.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc161e289e8826a1f3815cc8adaf0bec83a97b14ab3d512a90b00d594c47408d"},
+    {file = "habluetooth-3.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05bad2935ba55cf044275e7b160c7b2de4016d1cd4ac19a11887d6a520d3f5ec"},
+    {file = "habluetooth-3.25.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ea9ce9336c1ffad58de0cd711accc50d3e7ece708ff2e2841e340802110e738"},
+    {file = "habluetooth-3.25.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:19406da090e1470c9ad1a5278709af0a3908a4eb571d45ef4b1d5a0811c0188e"},
+    {file = "habluetooth-3.25.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:506711a9d0d8d3e3ef76637f83dc0e79c54a99b9ca3e63fb948a815a82b58484"},
+    {file = "habluetooth-3.25.0-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:983f41ddfac50c2b64d2a6f6075867dcd317674b587431952082deb1e0ad9023"},
+    {file = "habluetooth-3.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b2c67218d6d52d68096344ee78b7495d7ba6c98cf1f4c58cfe4d2ae7c4c9484b"},
+    {file = "habluetooth-3.25.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:bbaecbec7399237a53e5b982b5a42d3815f3cfb85a589da4d145d61b081fc9c2"},
+    {file = "habluetooth-3.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f54a08f98597d1802c6193050fa159756785a63a930cb8c91ffaf02dfafefb9e"},
+    {file = "habluetooth-3.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:09628aa0f38fe1adebe104da1a3debe9b6e26fc633deb98d2fc27e9e4dc265ce"},
+    {file = "habluetooth-3.25.0-cp311-cp311-win32.whl", hash = "sha256:d93dc890d5174a196231ad0a0fd9d2ebdf676a99b8bc5e2b96997c51017ccba8"},
+    {file = "habluetooth-3.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:c6141c75ed613e00391908d3fb23a3222b0aab92651b0d97c4f4af8c7e0cefd2"},
+    {file = "habluetooth-3.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a90dfa46cae5228f387d9a7656a1523f8940d1d12531f69d58c3a94da17dc9e2"},
+    {file = "habluetooth-3.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a8ce8cbb67dee2344595f04d5d6eb85eabcabe160af12280977e63058a64683"},
+    {file = "habluetooth-3.25.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2abaa05e885ec057c6295be6e203b09548636ff95f6ad3ad8de61b6bb8daf3b6"},
+    {file = "habluetooth-3.25.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:fb50c68e56cde6fee7dfc498d3dfbdab165197d6405c212f08762b8bb72bfda9"},
+    {file = "habluetooth-3.25.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb69ceb7b1565da7c77e603ada31a0e37c716eaae348daf6710036c0fe3b36bc"},
+    {file = "habluetooth-3.25.0-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57d20167b4eee6a6d71c696c38fb7ba7173924fec83a5b6d79388891b07f80a1"},
+    {file = "habluetooth-3.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e29086f77fec2b62d8082760f7c2c85d42dcddc40ea29e72ef90bd0fb1a41b4"},
+    {file = "habluetooth-3.25.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ea51ffab80db71becfa00b0c0c18d533cad85f3dbafa1a6fddceb42adc8f010a"},
+    {file = "habluetooth-3.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d05816ff385b18520c8c9110f7345a92defebe0cab8946e3757244fa9ea3546b"},
+    {file = "habluetooth-3.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9fa54f30a08dddbb5b128b5c9e8da175e45fa70a70729283a3eaf17b6a7"},
+    {file = "habluetooth-3.25.0-cp312-cp312-win32.whl", hash = "sha256:0019b685154a20278f808863e2917516f857fa48a6aef32912ae0ed6c4a7a298"},
+    {file = "habluetooth-3.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:feb75c919bde908ac8763df47392131645ccde2f428cea9cce5208a13029ac81"},
+    {file = "habluetooth-3.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:907bf61fde71e7ab75945b51cd210bf1fee30fec84aec74863a50cb3c38dccc4"},
+    {file = "habluetooth-3.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a4cb08ce58fb22c163a38a593b88dace8e75f351bff4717bed813a45181e5e4"},
+    {file = "habluetooth-3.25.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295266b916f6329932f89f5f9afb41c25894dcba6e90ad8946020e121b49848"},
+    {file = "habluetooth-3.25.0-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:8d8afa675065b09ead39457a69702c9a1172a933b35918f7350c3bef10d806e8"},
+    {file = "habluetooth-3.25.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07099b5e0726e067eefb5ae691a3709705db3338ad7aa7a898239b3ffdb5bc9c"},
+    {file = "habluetooth-3.25.0-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1343a3a06c13741be650e20f75823552ee895af508ace7f2517a55107a7cbb10"},
+    {file = "habluetooth-3.25.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:a1271269272b416561944d53fffdf7d877f974fbab384fdcf40438a5df93316b"},
+    {file = "habluetooth-3.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:70fdb8cbb7356e485d85be69dd154938ad96598fd674669857ad79926c3850d0"},
+    {file = "habluetooth-3.25.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:1ea860cbf2ac0152bb74e0d655f30a3cf4510c074bd25202214e7b8f73f955d4"},
+    {file = "habluetooth-3.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:fd9d7006372b3b4aecb59596e5b48801150ff54b8e3ebb54fc00f1319cfd6b2e"},
+    {file = "habluetooth-3.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60f5ef08a28e0c16710dac10eb2b5922dfcbb2f63d745e873ff9b4abb15b0239"},
+    {file = "habluetooth-3.25.0-cp313-cp313-win32.whl", hash = "sha256:e1e82c17e154f7f46e064ebeab3b10785c3fe7f0fd0e23710ceaa746720d86ff"},
+    {file = "habluetooth-3.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:5f682528d533c95f31174de4678a319dff65578616b7266ec2436c74ebfb78ec"},
+    {file = "habluetooth-3.25.0.tar.gz", hash = "sha256:5f1d3b20a4fd2bcebc642bd57f340485aceeed59a47b0e82589db4ec39afd57e"},
 ]
 
 [package.dependencies]
@@ -905,14 +952,14 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["docs"]
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]
@@ -1215,23 +1262,21 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "5.29.3"
+version = "6.30.0"
 description = ""
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
-    {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
-    {file = "protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f"},
-    {file = "protobuf-5.29.3-cp38-cp38-win32.whl", hash = "sha256:84a57163a0ccef3f96e4b6a20516cedcf5bb3a95a657131c5c3ac62200d23252"},
-    {file = "protobuf-5.29.3-cp38-cp38-win_amd64.whl", hash = "sha256:b89c115d877892a512f79a8114564fb435943b59067615894c3b13cd3e1fa107"},
-    {file = "protobuf-5.29.3-cp39-cp39-win32.whl", hash = "sha256:0eb32bfa5219fc8d4111803e9a690658aa2e6366384fd0851064b963b6d1f2a7"},
-    {file = "protobuf-5.29.3-cp39-cp39-win_amd64.whl", hash = "sha256:6ce8cc3389a20693bfde6c6562e03474c40851b44975c9b2bf6df7d8c4f864da"},
-    {file = "protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f"},
-    {file = "protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620"},
+    {file = "protobuf-6.30.0-cp310-abi3-win32.whl", hash = "sha256:7337d76d8efe65ee09ee566b47b5914c517190196f414e5418fa236dfd1aed3e"},
+    {file = "protobuf-6.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:9b33d51cc95a7ec4f407004c8b744330b6911a37a782e2629c67e1e8ac41318f"},
+    {file = "protobuf-6.30.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:52d4bb6fe76005860e1d0b8bfa126f5c97c19cc82704961f60718f50be16942d"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:7940ab4dfd60d514b2e1d3161549ea7aed5be37d53bafde16001ac470a3e202b"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:d79bf6a202a536b192b7e8d295d7eece0c86fbd9b583d147faf8cfeff46bf598"},
+    {file = "protobuf-6.30.0-cp39-cp39-win32.whl", hash = "sha256:bb35ad251d222f03d6c4652c072dfee156be0ef9578373929c1a7ead2bd5492c"},
+    {file = "protobuf-6.30.0-cp39-cp39-win_amd64.whl", hash = "sha256:501810e0eba1d327e783fde47cc767a563b0f1c292f1a3546d4f2b8c3612d4d0"},
+    {file = "protobuf-6.30.0-py3-none-any.whl", hash = "sha256:e5ef216ea061b262b8994cb6b7d6637a4fb27b3fb4d8e216a6040c0b93bd10d7"},
+    {file = "protobuf-6.30.0.tar.gz", hash = "sha256:852b675d276a7d028f660da075af1841c768618f76b90af771a8e2c29e6f5965"},
 ]
 
 [[package]]
@@ -1363,14 +1408,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
@@ -1610,14 +1655,14 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "8.2.1"
+version = "8.2.3"
 description = "Python documentation generator"
 optional = false
 python-versions = ">=3.11"
 groups = ["docs"]
 files = [
-    {file = "sphinx-8.2.1-py3-none-any.whl", hash = "sha256:b5d2bb3cdf6207fcacde9f92085d2b97667b05b9c346eaec426ca4be8af505e9"},
-    {file = "sphinx-8.2.1.tar.gz", hash = "sha256:e4b932951b9c18b039f73b72e4e63afe967d90408700ec222b981ac24647c01e"},
+    {file = "sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3"},
+    {file = "sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"},
 ]
 
 [package.dependencies]
@@ -1641,7 +1686,7 @@ sphinxcontrib-serializinghtml = ">=1.1.9"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.394)", "pytest (>=8.0)", "ruff (==0.9.7)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
+lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.395)", "pytest (>=8.0)", "ruff (==0.9.9)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
 test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "pytest-xdist[psutil] (>=3.4)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
 
 [[package]]
@@ -1787,14 +1832,14 @@ test = ["pytest"]
 
 [[package]]
 name = "starlette"
-version = "0.46.0"
+version = "0.46.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "starlette-0.46.0-py3-none-any.whl", hash = "sha256:913f0798bd90ba90a9156383bcf1350a17d6259451d0d8ee27fc0cf2db609038"},
-    {file = "starlette-0.46.0.tar.gz", hash = "sha256:b359e4567456b28d473d0193f34c0de0ed49710d75ef183a74a5ce0499324f50"},
+    {file = "starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227"},
+    {file = "starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230"},
 ]
 
 [package.dependencies]
@@ -1963,81 +2008,81 @@ anyio = ">=3.0.0"
 
 [[package]]
 name = "websockets"
-version = "15.0"
+version = "15.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "websockets-15.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5e6ee18a53dd5743e6155b8ff7e8e477c25b29b440f87f65be8165275c87fef0"},
-    {file = "websockets-15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ee06405ea2e67366a661ed313e14cf2a86e84142a3462852eb96348f7219cee3"},
-    {file = "websockets-15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8711682a629bbcaf492f5e0af72d378e976ea1d127a2d47584fa1c2c080b436b"},
-    {file = "websockets-15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94c4a9b01eede952442c088d415861b0cf2053cbd696b863f6d5022d4e4e2453"},
-    {file = "websockets-15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:45535fead66e873f411c1d3cf0d3e175e66f4dd83c4f59d707d5b3e4c56541c4"},
-    {file = "websockets-15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e389efe46ccb25a1f93d08c7a74e8123a2517f7b7458f043bd7529d1a63ffeb"},
-    {file = "websockets-15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:67a04754d121ea5ca39ddedc3f77071651fb5b0bc6b973c71c515415b44ed9c5"},
-    {file = "websockets-15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:bd66b4865c8b853b8cca7379afb692fc7f52cf898786537dfb5e5e2d64f0a47f"},
-    {file = "websockets-15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a4cc73a6ae0a6751b76e69cece9d0311f054da9b22df6a12f2c53111735657c8"},
-    {file = "websockets-15.0-cp310-cp310-win32.whl", hash = "sha256:89da58e4005e153b03fe8b8794330e3f6a9774ee9e1c3bd5bc52eb098c3b0c4f"},
-    {file = "websockets-15.0-cp310-cp310-win_amd64.whl", hash = "sha256:4ff380aabd7a74a42a760ee76c68826a8f417ceb6ea415bd574a035a111fd133"},
-    {file = "websockets-15.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dd24c4d256558429aeeb8d6c24ebad4e982ac52c50bc3670ae8646c181263965"},
-    {file = "websockets-15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f83eca8cbfd168e424dfa3b3b5c955d6c281e8fc09feb9d870886ff8d03683c7"},
-    {file = "websockets-15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4095a1f2093002c2208becf6f9a178b336b7572512ee0a1179731acb7788e8ad"},
-    {file = "websockets-15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb915101dfbf318486364ce85662bb7b020840f68138014972c08331458d41f3"},
-    {file = "websockets-15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:45d464622314973d78f364689d5dbb9144e559f93dca11b11af3f2480b5034e1"},
-    {file = "websockets-15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ace960769d60037ca9625b4c578a6f28a14301bd2a1ff13bb00e824ac9f73e55"},
-    {file = "websockets-15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7cd4b1015d2f60dfe539ee6c95bc968d5d5fad92ab01bb5501a77393da4f596"},
-    {file = "websockets-15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4f7290295794b5dec470867c7baa4a14182b9732603fd0caf2a5bf1dc3ccabf3"},
-    {file = "websockets-15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3abd670ca7ce230d5a624fd3d55e055215d8d9b723adee0a348352f5d8d12ff4"},
-    {file = "websockets-15.0-cp311-cp311-win32.whl", hash = "sha256:110a847085246ab8d4d119632145224d6b49e406c64f1bbeed45c6f05097b680"},
-    {file = "websockets-15.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7bbbe2cd6ed80aceef2a14e9f1c1b61683194c216472ed5ff33b700e784e37"},
-    {file = "websockets-15.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cccc18077acd34c8072578394ec79563664b1c205f7a86a62e94fafc7b59001f"},
-    {file = "websockets-15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4c22992e24f12de340ca5f824121a5b3e1a37ad4360b4e1aaf15e9d1c42582d"},
-    {file = "websockets-15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1206432cc6c644f6fc03374b264c5ff805d980311563202ed7fef91a38906276"},
-    {file = "websockets-15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d3cc75ef3e17490042c47e0523aee1bcc4eacd2482796107fd59dd1100a44bc"},
-    {file = "websockets-15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b89504227a5311610e4be16071465885a0a3d6b0e82e305ef46d9b064ce5fb72"},
-    {file = "websockets-15.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56e3efe356416bc67a8e093607315951d76910f03d2b3ad49c4ade9207bf710d"},
-    {file = "websockets-15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f2205cdb444a42a7919690238fb5979a05439b9dbb73dd47c863d39640d85ab"},
-    {file = "websockets-15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:aea01f40995fa0945c020228ab919b8dfc93fc8a9f2d3d705ab5b793f32d9e99"},
-    {file = "websockets-15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a9f8e33747b1332db11cf7fcf4a9512bef9748cb5eb4d3f7fbc8c30d75dc6ffc"},
-    {file = "websockets-15.0-cp312-cp312-win32.whl", hash = "sha256:32e02a2d83f4954aa8c17e03fe8ec6962432c39aca4be7e8ee346b05a3476904"},
-    {file = "websockets-15.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc02b159b65c05f2ed9ec176b715b66918a674bd4daed48a9a7a590dd4be1aa"},
-    {file = "websockets-15.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d2244d8ab24374bed366f9ff206e2619345f9cd7fe79aad5225f53faac28b6b1"},
-    {file = "websockets-15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3a302241fbe825a3e4fe07666a2ab513edfdc6d43ce24b79691b45115273b5e7"},
-    {file = "websockets-15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:10552fed076757a70ba2c18edcbc601c7637b30cdfe8c24b65171e824c7d6081"},
-    {file = "websockets-15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c53f97032b87a406044a1c33d1e9290cc38b117a8062e8a8b285175d7e2f99c9"},
-    {file = "websockets-15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1caf951110ca757b8ad9c4974f5cac7b8413004d2f29707e4d03a65d54cedf2b"},
-    {file = "websockets-15.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bf1ab71f9f23b0a1d52ec1682a3907e0c208c12fef9c3e99d2b80166b17905f"},
-    {file = "websockets-15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bfcd3acc1a81f106abac6afd42327d2cf1e77ec905ae11dc1d9142a006a496b6"},
-    {file = "websockets-15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c8c5c8e1bac05ef3c23722e591ef4f688f528235e2480f157a9cfe0a19081375"},
-    {file = "websockets-15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:86bfb52a9cfbcc09aba2b71388b0a20ea5c52b6517c0b2e316222435a8cdab72"},
-    {file = "websockets-15.0-cp313-cp313-win32.whl", hash = "sha256:26ba70fed190708551c19a360f9d7eca8e8c0f615d19a574292b7229e0ae324c"},
-    {file = "websockets-15.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae721bcc8e69846af00b7a77a220614d9b2ec57d25017a6bbde3a99473e41ce8"},
-    {file = "websockets-15.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c348abc5924caa02a62896300e32ea80a81521f91d6db2e853e6b1994017c9f6"},
-    {file = "websockets-15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5294fcb410ed0a45d5d1cdedc4e51a60aab5b2b3193999028ea94afc2f554b05"},
-    {file = "websockets-15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c24ba103ecf45861e2e1f933d40b2d93f5d52d8228870c3e7bf1299cd1cb8ff1"},
-    {file = "websockets-15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc8821a03bcfb36e4e4705316f6b66af28450357af8a575dc8f4b09bf02a3dee"},
-    {file = "websockets-15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc5ae23ada6515f31604f700009e2df90b091b67d463a8401c1d8a37f76c1d7"},
-    {file = "websockets-15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ac67b542505186b3bbdaffbc303292e1ee9c8729e5d5df243c1f20f4bb9057e"},
-    {file = "websockets-15.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c86dc2068f1c5ca2065aca34f257bbf4f78caf566eb230f692ad347da191f0a1"},
-    {file = "websockets-15.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:30cff3ef329682b6182c01c568f551481774c476722020b8f7d0daacbed07a17"},
-    {file = "websockets-15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:98dcf978d4c6048965d1762abd534c9d53bae981a035bfe486690ba11f49bbbb"},
-    {file = "websockets-15.0-cp39-cp39-win32.whl", hash = "sha256:37d66646f929ae7c22c79bc73ec4074d6db45e6384500ee3e0d476daf55482a9"},
-    {file = "websockets-15.0-cp39-cp39-win_amd64.whl", hash = "sha256:24d5333a9b2343330f0f4eb88546e2c32a7f5c280f8dd7d3cc079beb0901781b"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b499caef4bca9cbd0bd23cd3386f5113ee7378094a3cb613a2fa543260fe9506"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:17f2854c6bd9ee008c4b270f7010fe2da6c16eac5724a175e75010aacd905b31"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89f72524033abbfde880ad338fd3c2c16e31ae232323ebdfbc745cbb1b3dcc03"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1657a9eecb29d7838e3b415458cc494e6d1b194f7ac73a34aa55c6fb6c72d1f3"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e413352a921f5ad5d66f9e2869b977e88d5103fc528b6deb8423028a2befd842"},
-    {file = "websockets-15.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8561c48b0090993e3b2a54db480cab1d23eb2c5735067213bb90f402806339f5"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:190bc6ef8690cd88232a038d1b15714c258f79653abad62f7048249b09438af3"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:327adab7671f3726b0ba69be9e865bba23b37a605b585e65895c428f6e47e766"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bd8ef197c87afe0a9009f7a28b5dc613bfc585d329f80b7af404e766aa9e8c7"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:789c43bf4a10cd067c24c321238e800b8b2716c863ddb2294d2fed886fa5a689"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7394c0b7d460569c9285fa089a429f58465db930012566c03046f9e3ab0ed181"},
-    {file = "websockets-15.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ea4f210422b912ebe58ef0ad33088bc8e5c5ff9655a8822500690abc3b1232d"},
-    {file = "websockets-15.0-py3-none-any.whl", hash = "sha256:51ffd53c53c4442415b613497a34ba0aa7b99ac07f1e4a62db5dcd640ae6c3c3"},
-    {file = "websockets-15.0.tar.gz", hash = "sha256:ca36151289a15b39d8d683fd8b7abbe26fc50be311066c5f8dcf3cb8cee107ab"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
+    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
+    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
+    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
+    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
+    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
+    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
+    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
+    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
+    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
+    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
+    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
+    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
 ]
 
 [[package]]


### PR DESCRIPTION
dependabot is still broken with poetry 2 so
we need to do this manually