### PR TITLE
chore: update deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,63 +2,63 @@
 
 [[package]]
 name = "aioesphomeapi"
-version = "29.7.0"
+version = "29.8.0"
 description = "Python API for interacting with ESPHome devices."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:705c4637151bf73f693a0423ac66910e9a1d65ab2443191b8ae853d024b21ed1"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:079be9adf32f0ef0d05e672e2da9611d188f469c58c811799e4b3366deee81eb"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1843edc09850d0524cde7b10176c93d79a57e96ba22535658a25c809886e1df"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b5c4763ff01ca1be8473e0164a55b1366efd3809ae54e88909948f353e6b41c1"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e633ae5ce32d47dcd0bd1ea724a47041450381c02f9172cfbe74f58272204b5e"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03cf57ee2d9aaf4a33913fcc3131499cfcdb7be9d9ff0eeaa2542e03d663d132"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9a9f6e8ca7ad5669823de7d8dd61f6f9e00ae7ee5be873bbfb92f9f5f21aa93d"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bbdb809696cc142e2bf4382ac0af069903f8b69df4908f0611a8344750cb5b27"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1fb6efa3271256f1b2f6a48d6962e5279d61174b866ac433f4e9c9e15d845b25"},
-    {file = "aioesphomeapi-29.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2c9c02ad22e3bc2b275c0b06f1b07184d0f00db18d5d2529ad5e4c96d6fbd985"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:42c418c2eeff40f61b64ebf919eea1186ed6d91767971d8592e6a795bf254a4e"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24ecdb2c00bb1d1316bf7ce1e5a45c3bacbc74c20e957c2dce5af9f8e9c8150a"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fc24fbe7e1e186ddefbb6e2fd45e690084fcac7dfe7db8e2121f73d4b3e736f"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:756faf630c2ddd55da62382ea393c4c1c6c2e51643c6c966d8d8eaba63965b45"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d90cba965c62ca1b0ed04b674550148a38703a8fd42f3e47c5ed7127aa33e7ec"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0eaed26bde32aabed54b9db7d7685b43742833f04d4e524afcac75eca68505c"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2d7e5ffb47fd47b29bd6d66fcc5f73ec5173ea699a49cb529a624d972ec1dc36"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:9cc0f91c47d1d4fff6cbc972a98167d26bda871cfbda0b0cbd704cc8e9b830c4"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a7fa9fd81ac6d40638c118f82198942f728b2f11a20aac6830c8cf75dd7706f5"},
-    {file = "aioesphomeapi-29.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1a02600a4cb3162595b2d714798ee3c384a1031c757d808137d5fd93508dccaa"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ce85a3c53b94715c03ba86e9e240241fe80b54b4ada3af6fd3c447434647d749"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:49f496e907303750bba0d36ecfae63c61e22cf211de96d5b89fd84ca9e2ea163"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3afb17fbc7bdb470a9e8e5e45cf44bad9db36a372745d7d146f3946045b1cdc3"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6c12251d3ff16ac5a7cfba8a9da6b918d04b755d123f108d7f6c8afbd3281158"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:480d0df7d0ffae64bcc80a2e56adb061f8f177df9fb94445ae5264298950f635"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:556aff77a3898b62d50b35e06acb5e130591bbfa3c73b44ef9ed67500a5151cc"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f04168a470be3039405b5eb8208eb45b6e5943b0c6c376219fea264eb44a9194"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7f5c28d047b4657259ee0613b01cf700ab4bbcf225be7f3cb3ede015613576a3"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3f275c66bf50722cdcf825b948219ff5e485a48c53efa0e25cf89d1db0da512e"},
-    {file = "aioesphomeapi-29.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5f687838bc56f1b78f7b23619875f99a4688078b28aaad4302038006730bcf41"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:980ed6a22f9cff2f39b88bcd1a82a636638a621e138863304ccd00df5aaef474"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:244753864d0b1c4700be9e0d32b948a7a869972baa812ac583f36d76d65c49ce"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4be1b8b0891f08891503768617f6ccb3d957f839b60750683bc5e3b539496f43"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:782a0f07af87f1727252edfad8e1d3a4fdf64dd859c9cc0fcaab956c2887e0ab"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bba2057f926113a1978d430e3e4b5d3046fc9868f80f7ffbaa275a771b0c9c06"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51cfa1336eb58443ba7370465459f1e61df114ef9483808f34d30f896c2354a9"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d5376b3ca5fd55d0ed4ce6f09933b01a665c59328b3029235a3cbebdd5ec565d"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:52c3610db4735d89baf12c133f320471706f06f697cab3433d57ea5c95b07702"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:51ccd3bb37b077dfe23b3cac143ace031e82a7f11e2bd9bc26c46f496af6fb78"},
-    {file = "aioesphomeapi-29.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7dd6371822429a4b2604f8f20d26fd710998c7fc0a781d85a04df84b7eccd46"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:002f44640a625c93737c68f9849bc538e0c0c9a508e0da18d46a212b51b1b1b4"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fa6b4447cc3437728ec530f416bad5af13c85ba2fb50eeba4132a2ed492e675d"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4af364f8c98f1ad0776ce0ddc475ed1e34a17ace576c53858d56257495fd622"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c78965feeaaee02d344e64bc3ae87fe07fd26e4e45f81c63ba0012d2408522b7"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c23e9715914744b82f9d09aaf730ee9508cc69ecfcf0b4dfb7dafcd66e839d05"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03cb66304dce07282130076462492b793a948bfa59ab79533047408879a0af55"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a394fc0913b464908c9d0e8620250bb9aabcc75cb3875314bba508bc2c09b109"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:aa31d1265eb93b5ae5e5cf640e858ba69b288c8cdda8ece4acecc2746a0f4351"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a0aded364ca7a2bf36660035a422154901d6df0039b2a8b0414b79562b87e5fc"},
-    {file = "aioesphomeapi-29.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6ca71f8893e46a47032d344b8d2874d669a085abd87f4c08d199a358d3709a19"},
-    {file = "aioesphomeapi-29.7.0.tar.gz", hash = "sha256:267b740eec8044948ed5c581f929ac2c093ada827999aa5566c6a71232f23059"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df6ca3acec2b59a785358ad087db1b17ff1a9967a5b211222728f88a9258f3f1"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9dda5edc9852f386a3096653231d80b01d0d60721c99f18c42197d3a02deef14"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fdc1d146966cfe25513adb985536731f9b3462757c5a1ca769d9465d24d97af"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:efdc2a35353b1ccdc67265a9e162095b270716cd0fff3f6332dffcf9c9cb90bd"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00507a6a560ea96c7db87a832a4aef5d95c2744851fffa11cdc6aa91a88ecdde"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d22aef5d5e40464c7aa66c7ec7b6e122185ca845f07930a713e703f694e8d752"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7b68176aa2b520015687661c7310827e2069e55b8c184b8f24e1ff021ac3336f"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b8c226cd46c756afb3a3f54c75270b460923e96d5936b5d1852283f2e4d00930"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c6ea670566faa18871001575cc660fdf7967ecf819d146b3a3544406da9f59e9"},
+    {file = "aioesphomeapi-29.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ab82999350ce3b9b92a296846cb426e7e1a5605d2e3062cfe61bcf713b0b38e2"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e82ba94f77146ab161754d2c09b2c35ccd58c1b71f8a24033ded75c2b5d008f5"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1042f1b2227c0c3ccb9514f722f388746317dcbfaa363c64e79c32f15bf3898c"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21503d365a74b45093e11913ee297b576e26047d49b0250383364a3e09a38b54"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5399bdb5dafbd70045767742c5ae5503535f1fe43b12d5306316ec74c3b490ba"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bf10a3b884807fb323c0cf0d67cddca47c259a1283f98d7c52131f3c49319e3"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15f42a0f41f614e3b77894fea2f4063f951c2a87d741f5a44ffcc31925354385"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b77310c56bfc2cab3a7a2e07786e98f3d604e28ccc3b9e111f790837a8dd8787"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:b3269c023f2962f677fd303bbe9a72c130b4c5ee9c9c486a71e76c45a0c50775"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bb219ac0d30b4e12bfda93ec4eed89f6b964e3430d46181a4d8af9ee54b25d0a"},
+    {file = "aioesphomeapi-29.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f54407b3d4622944ae78b81d044fb76713a5c642defbcb172a960c44c5a2626e"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f8627ef90e26f9f05c18b00a3c2aed3fdf8a72adffe4d2cd3a00567bd8fe8ee0"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:324628744b250a34d01c313f6dd11f3af02de207c5166e52b6569f64bc61bcd6"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eafad9d58e27f7fcd9f5264405df5abf3efd124104b03ee653f1dcf7e1a16947"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c6d48ebb55b04fa31db103be95dcab72cf1b5407aac244a844de7f1d4b8a8d40"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b127e29caf93d457a6ddc57a44a62678550adf0d55b6fb2ca40bb70844f0daf8"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9bacdd8d1c759481b6e7a2add0ea4cafaf421389ff7cb35b97e193108b25960"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:add0a4d00ff77581aae1ffd56ac536877609de0672678242b996bc16dbea3c9a"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a3e698501ab5610102dafc97c9e7cfc3c5f32fc72757db5370f8de2ad2c7b962"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c093fbb1163c9a94750c7b9025106f7ff78994e53d5cf23a50005e49b6a7dbca"},
+    {file = "aioesphomeapi-29.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:68b9d911d5bc81c59f28309a27ab4e0265aaf4f4c00c87f837241c5293935e84"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:81e6ee352111ed6522667e2520b26beddb2605e3f743d4d13e52967a4611af89"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6837695ea57a58b61451d18a501627078f83b430d25aa27c5ed61c93141cf84"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dedd638a3047a6d700e023929af9b5bdb4a9c0a2beadfd3d444da4729357d1d"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:da9d05dfc378bac223e40f4231978545418fa1d7357aa771ec64babb70d96e38"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b1712f4ca9be3486534492123906786e39885abdaf31496835ec0692a63f9f3"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f25917997f7d6adf1e7cad3951be95d8a001e244491ed912a642131b55f7a8c0"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1e633a16435a1a3319325cfec514f98d5ab2f5ca9994c9ab6b8460a50c930abc"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7062189c566ea6919733c1257f2c9433f822e07cf802e07d5e79d9e012536149"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:22b11d0f1f1e379248855bc3e4f88c4b11a220c7801374a5fd4ab47415cbb4a6"},
+    {file = "aioesphomeapi-29.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:273afdd8a878a4bcaa55f20988c340b1e409e8fc70cd5b17fa8a8819f61ea969"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6083885388bf0f326b71e4ff355c588a4c6fca41894c850ae2caeb4ee2aa39b0"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6e5dd06ae28cd10bade8d4ba09879fa242d64b7a54bd92ad318201144c86fbc3"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c7a551f411e774342b879baa079d928f25bc373f15a593638c045bad7a71caf"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ff0747fbc0c70170c8a46837acf369cc2b5a05207979b9ef6dd563bb12c3ccda"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:529c78b0e548f1997805da7224a6bb9f37ea2d5a6c43969022b79bfa1debb3b1"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:37027fbea9fca398c3e2d2e6aad9709fd818fe6326fd49b928c629bca65c5e5d"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8d19afab3c21130bfe0b7e79aadf63cb0e471e8522ccca16d92fb2db7949b827"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:b33162ee12b94d53a54b126b71d9f3e98d5b62343b8d353eb149c6c5309bf187"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:de86db988164e51c9a5bc0006c051d334ad7305ef9e9b37efbb5ac66d1d2fe34"},
+    {file = "aioesphomeapi-29.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0ef2cd143cf7f8feacfd7b7d0506b6902c07763da5ecfe19a7203ed79749eee4"},
+    {file = "aioesphomeapi-29.8.0.tar.gz", hash = "sha256:1419a4e8a96fa9d90bb06dc871ecd408381843f597431d7388c15c5410ddfc9b"},
 ]
 
 [package.dependencies]
@@ -209,19 +209,19 @@ winrt-runtime = {version = ">=2,<3", markers = "platform_system == \"Windows\" a
 
 [[package]]
 name = "bleak-retry-connector"
-version = "3.9.0"
+version = "3.10.0"
 description = "A connector for Bleak Clients that handles transient connection failures"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bleak_retry_connector-3.9.0-py3-none-any.whl", hash = "sha256:6f7711c3c39b60f3dea5963abe40de3514165e912c9fe7e11a88f36104aa5644"},
-    {file = "bleak_retry_connector-3.9.0.tar.gz", hash = "sha256:5c772298b86bcd3b46a57b16cdd9aa5fca9434ebcf87d72493af94e4f4ca2a6e"},
+    {file = "bleak_retry_connector-3.10.0-py3-none-any.whl", hash = "sha256:caaf976320ef280f1145b557bf3b13697f71ef2c1070e1dc643709eb2d29fb1f"},
+    {file = "bleak_retry_connector-3.10.0.tar.gz", hash = "sha256:a95172bd56d2af677fb9e250291cde8c70d8f72381d423f64e48c828dffbc93b"},
 ]
 
 [package.dependencies]
-bleak = ">=0.21.0"
-bluetooth-adapters = {version = ">=0.15.2", markers = "platform_system == \"Linux\""}
+bleak = {version = ">=0.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.14\""}
+bluetooth-adapters = {version = ">=0.15.2", markers = "python_version >= \"3.10\" and python_version < \"3.14\" and platform_system == \"Linux\""}
 dbus-fast = {version = ">=1.14.0", markers = "platform_system == \"Linux\""}
 
 [[package]]
@@ -291,62 +291,62 @@ docs = ["Sphinx (>=5,<8)", "myst-parser (>=0.18,<3.1)", "sphinx-rtd-theme (>=1,<
 
 [[package]]
 name = "bluetooth-data-tools"
-version = "1.26.1"
+version = "1.27.0"
 description = "Tools for converting bluetooth data and packets"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:478b35ff52e1f8721ccce4db0d52b0592f2ae7a4a2b6cf0ba569f93c95a6457f"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4904dfd1c6ae991f9c325653870902a0055f5c3d3ff314097b3fa160267b4063"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e6268a2b9bfc6347a58f1422fd258bd9724e6dd4927b23fc704d59227240fc"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bae01f31d947726505c8fc86d945e803aa7a675e8d58b3d80f384d9b8fe3edfa"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1eac3b2a1121f14c8e8d19926acfa97197777ab1eb32c71b261851de9883973"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f22eb3c4b07a486b24174b48754fc237a89437c0c2485f2aca1e7341cfa1042"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:284c4e7458728f0f09537bc759cf29f87f00a413f6c3e0f64375563a0098d0d0"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:13c03893e179d267fb75a30bc122ee3be86c22fc1a4cb2265446a2bc9047d232"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0c5b2a71df962dcab9a8c2e5e64436f65c599398ae15f725b43605d516b2ade3"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:172d7ac720d12740ea73073862c648a1a2bdc2f13bdbae84918a770f718138fd"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-win32.whl", hash = "sha256:9ce18eed96eff7eb5cdfbeb66e9f73813f3facb6671e40a4c2bc78e6d8e88ef3"},
-    {file = "bluetooth_data_tools-1.26.1-cp310-cp310-win_amd64.whl", hash = "sha256:cc3a2c777e495e7084e2cbd1be4af05c06f6a309ede87a90a38896501675dbad"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c114f636f063d4140249af06d45838cd20f88c598c3ea8d3ee2995e6f40c9af"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2c69043f538103d5b2413c8e34b1c1437dc9a7e10c6e1f0427d1374e0cdecf19"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9485bbcfaa245ae0528cf4ec9d81576629a5a67ae16d6e672a6ec251c741e07"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e226e87b952914e3b5ccf8679ca2c265a3c2a8f488ac4e15da62acfa6c57b191"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9224e515c35a537d8474aa365caa2754b5e27f0166d7be20d530961fac9cdf"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8d010574afd042da067b3de4b9c36fab1383d7d54f6d1268c5d8f863d623b451"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f52a87531ff47d6f9762fdfa28f6837c64f82e152205bb2bc097353f530b9f1f"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:365717de5460e4d703aeb99accccf98f37a0deffbccfc366853507376fe378a5"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e0911b1d0dedd22bc1d9c797d975a52dc6e9e0a0d625702486bd1277b07994ad"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90ae35d7c8885ee04000f155aa1e03de4a94c95557e05c75fb3cfc0744c0515c"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-win32.whl", hash = "sha256:b97b21842103784bc915ab36bf48ea93e0e9a550f3fd435afba8bee0fd26b8c3"},
-    {file = "bluetooth_data_tools-1.26.1-cp311-cp311-win_amd64.whl", hash = "sha256:ff8848df5581b5f9c3e91234ba2c6e883e0c6f5ce45516611bb3c4abca7c4d97"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:23763282ff1a2a03714df132bf5799b3e65ee5595b8c089b017cace23bbdcfeb"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a4b3c8e30f0fa102bcff49147bb74ceea148c1f40e30245bad2a3c1db7e9dcc"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61c46ac423bcf685e2b3348abc2264d55216209470df316830385fba593f5c52"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:858082adda19cb8811fee7cd33382d274ac469b76e39a038deefe99c6d74158e"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3295841a7b914a43417f7bf48efd6ddc856f703719e72f87add1fef587469b1"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a63d4e8587c575dfd6c3b3458c8ef7e3b82b0d25c96e4031b7e2efd886020a1f"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f346719adbf412234e13a7a910e19f25aeabf546d9f566cd15f9347264d51ae3"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:04abcd277966dea04a5288f5ceebd4c4b75c7ed99d599c6f40567249c54fcaff"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f0b15de4bbcd8ef4e389ffbbf2f71a00815b32381ac8784232b8d9c2ece4c934"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c127b31f164afecccce7231e9108baaae1fba096fa0dd2827028ebc0c2651723"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-win32.whl", hash = "sha256:f9c3c28945d76b6af5c043762f852eeec3e05c5a1a8f3ad3d21404ecb13748bb"},
-    {file = "bluetooth_data_tools-1.26.1-cp312-cp312-win_amd64.whl", hash = "sha256:221bd0d417d7ba1b5bc4ef0e5b723eb7bfc93c05c4105eed26423167b845ff66"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78c9f038199bd33003efb829892672b425cc2590bf7dc345d8802683c5c1efe8"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f1302034add12cca051ddd2efc079bcab834e5b6b1b31a7754e9696cfde1ed5"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a153f0b80f8e6b7113f7671fb22be7c6cbba06e416b3a031b46b5f053da0201e"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8bc5887e84d52a497d583c3f3bc383b3f49bd924b12eaad41327c064c413986e"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df3f34587f1bbf666d09d87774b9bfbf612d156e02d9883c22b377bc2670daa6"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e95d590596742387f6fd08a87a6bf461457560a18d3adb8e4568ed6f16975a97"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:1a39bff8b1afcdedfbc9dc523aa83b67b193f8207e156e08dcbd2c1b966a5738"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7507c387f7a2a044aad1ecd8200df1a4a296fa14f61ad46e1715c14fa83cd361"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:158e08a6a1f3768171a934160f737b058277e16c41c127b318821cac92f56a12"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:505bcd80a29d87effeeb7a8598a20caa2bba1071d817f541b1d17f7652221cb4"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:23c7618f42c12f46ce816b1c35f97ba64652d84849ef174de6b122c62c541282"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-win32.whl", hash = "sha256:d9566e283e21eb56f8bf7c1d22fa65b590eba6615fedfd80ee4c1ffa205bb401"},
-    {file = "bluetooth_data_tools-1.26.1-cp313-cp313-win_amd64.whl", hash = "sha256:d883322204f7ad53d22206b416364a7bdfca19601b984cae9fd138723ef10fae"},
-    {file = "bluetooth_data_tools-1.26.1.tar.gz", hash = "sha256:eb79cb21900cb0d35457719ed2c825049dc2268a7aac22e558f7ae35310c661e"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3476cc996fc7b9ccb194cfdcac9077ceca05adca748132c542100e5c0c12f01f"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d765b735598e81023c1908a9295cfbc7da677e44b39e628e6855980c3eb8617a"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fcbbca89c4f663d76f1c02adbeb3c4d388215e72309041952fdd6825c0573822"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:90867fbb34186ad1423f102e8a3e8d0fe8c28b04f47cf00e9f5890a4cb96a83d"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ae2815a09622034823ac4a31c6c55c1d05d0d8d69601f39d85bd1060dc14a1e"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98f7d29b0022baef920940acce2141c6f37c7116700d8c8e695858846b28c5f7"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:330aaaaba18e27076c968e2bff4721c6c2870b322afa0a33d6f9fa896e57e872"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e63c1ebd68c9cec044cb9c1aaf8b97e33eff479292b49bac111839a0f33a2e94"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7a476af0764c938ce67034c0bbfb55d3836abdc9cd6db93afe061049ee0e85fb"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:371f07602f77104e4a1ef668e1e37bceb2fc5555c99bb502a80dfbbb5056a14e"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-win32.whl", hash = "sha256:61af67930cb7a2003b76a5473428e82e1abf7810d9455b0e82e16b090cc9e842"},
+    {file = "bluetooth_data_tools-1.27.0-cp310-cp310-win_amd64.whl", hash = "sha256:a756319c91be42b274d139a698372dc7a4bd8947b70c0d075bd172ab6460184f"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fc427e284586118523e6be8e8ae7570faee389da1adafd7d37629e789213d7a8"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b242258e4f11f21a58481bda393858fb7b10cccdb89c1116ca5f1f5ada91e1e"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f195af462312b1eba11e4f05a3886e3d60f8723ea3e22e4279acbe48cb63e33"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83d4124b97b93328058824dd68e38b0b757afca9520b7b060092d2d6857acb1c"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fac40d307d4cf130492ed857eac1f86090c630877ce3f8a32635e26cdf4cd9b"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da30e50e32e5eefd8eafe1a97c9bc841b1c9bd8f781c06aa38cbd3d066e67a81"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33e95a01b5b536350b9191c9eb81d8ea0f31dc0f3d8bda4c3c87eb9614923669"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:b3fa5be1292a62dc2cbc7100754b438e285f52aa6c516163c8290dc3de23b094"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4bffda88019472a79adf32717d12658b4984815da524bd869900552042afac0c"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d5ee4ebdb8f9392ac0bc3df240567c5c4694abf908d6eaad96c4a247aa59261f"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-win32.whl", hash = "sha256:cf24e6745fba07f260ef110a3f72fc02ec59bc6766d0be61cdf40902d4626967"},
+    {file = "bluetooth_data_tools-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:bec46902713d90af12b11d3c912481b30e7ac67dc9ad1b5a408aca77fed69f4d"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e682735680499c4ca98465b3bc6f5ad7c46c7f1a607eb2e7bbf7dd04b104a51f"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:627254ae019d8118dd07bce98d8c5094d81bba56440d517f6871f628258ae324"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f18d90e447e7e5369b9be25af595f1c55b5963ff107c67d36979eb569cf3d37f"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c0453f1ad662825897e697f172b069332596c7cdcef6d845e655238a641bda2"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19650cbfd87a5a6d5035ddc92609d0e232dfda59acbf2cf91a6b17377a4804a1"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f16a070ab0683401d32f7035ed4a55939ac358f5ff1c614889c04513431c93e5"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b735aa08914585e6fbff930647f2ae7560d0e54d1951197901c6b817f1115929"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:84333c1469a1889f8401a65af25a90b39706ce6c272fb2c3aff1e7ed1d697547"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7149721d999148249dbe79cb1feca118951a3399612dcfd42903e2d9352b6262"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:956bf1e78542a5acab6dd2fc6b94c35803139494db869ab52c165db37536d822"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-win32.whl", hash = "sha256:27ec14322cc57156abec3b3949e5856ac4927f0c6049da28753045d70641a5e6"},
+    {file = "bluetooth_data_tools-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:d5d6545b63812d4668d10fc78c502c471b8dc88a8e8cfda9140895aa0251b7b7"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:caa6b35d5155ca3a734f4c802982827077eef5a1a3d71382c41237795d855244"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:53c98f8e87454c72f9d23ff200597f6fd92c8ec1b18cab035a36515e81568648"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d72c27b2d5629bb006fe4b21c788ed7a354a3a91ecec83c7dabc2dd8216326a9"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f136e90f6619691ae2bc31703418c826c4a5de5b934c38578753e0a0d4f32c33"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af8d4051a1ca20a9d1ac56a7b95f31819760ff26eed8ded6db7f9b3aed2e091b"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:88f4eb331238cd9ea8a7e130ff24befe1f824b722a6bd17559ed6e037c355581"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:e5eddbebfe870a8cb6c4befa65722d291ea7c1d024c77881e95baec0c9557b5e"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:61e81e699b44b17f870e18233bf4fc5e302e60614f7abcd2b721408116e38d34"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:92db6338630adf0d913dc05b92bf4c1ffbf2afd16bdb3958d1f31c9048995fd0"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:52e2c1e58cdac8d5095b7325ca9ecdd245895beded41aa4010362ac6bc64b1ec"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5670ec87ff733e428fa2763b5cf1744960207490f280eef9779f9549c6fa7742"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-win32.whl", hash = "sha256:4077e35f6ee7f95c5effa52ed06b75ce47aef67f67a614bd89908bd01573d777"},
+    {file = "bluetooth_data_tools-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:38fbbc466930c5c88f6fac23fa098870e2096dcbbe8dc4c63211526dcdf03bb4"},
+    {file = "bluetooth_data_tools-1.27.0.tar.gz", hash = "sha256:71d78caa1f8d280ebc3467a07b5948084ad3a4a6f5f2a7892b76bc08fec4bf9a"},
 ]
 
 [package.dependencies]
@@ -613,75 +613,75 @@ markers = {dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
-version = "7.7.0"
+version = "7.8.0"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a538a23119d1e2e2ce077e902d02ea3d8e0641786ef6e0faf11ce82324743944"},
-    {file = "coverage-7.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1586ad158523f4133499a4f322b230e2cfef9cc724820dbd58595a5a236186f4"},
-    {file = "coverage-7.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b6c96d69928a3a6767fab8dc1ce8a02cf0156836ccb1e820c7f45a423570d98"},
-    {file = "coverage-7.7.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f18d47641282664276977c604b5a261e51fefc2980f5271d547d706b06a837f"},
-    {file = "coverage-7.7.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a1e18a85bd066c7c556d85277a7adf4651f259b2579113844835ba1a74aafd"},
-    {file = "coverage-7.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:70f0925c4e2bfc965369f417e7cc72538fd1ba91639cf1e4ef4b1a6b50439b3b"},
-    {file = "coverage-7.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b0fac2088ec4aaeb5468b814bd3ff5e5978364bfbce5e567c44c9e2854469f6c"},
-    {file = "coverage-7.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3e212a894d8ae07fde2ca8b43d666a6d49bbbddb10da0f6a74ca7bd31f20054"},
-    {file = "coverage-7.7.0-cp310-cp310-win32.whl", hash = "sha256:f32b165bf6dfea0846a9c9c38b7e1d68f313956d60a15cde5d1709fddcaf3bee"},
-    {file = "coverage-7.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:a2454b12a3f12cc4698f3508912e6225ec63682e2ca5a96f80a2b93cef9e63f3"},
-    {file = "coverage-7.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a0a207c87a9f743c8072d059b4711f8d13c456eb42dac778a7d2e5d4f3c253a7"},
-    {file = "coverage-7.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2d673e3add00048215c2cc507f1228a7523fd8bf34f279ac98334c9b07bd2656"},
-    {file = "coverage-7.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f81fe93dc1b8e5673f33443c0786c14b77e36f1025973b85e07c70353e46882b"},
-    {file = "coverage-7.7.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8c7524779003d59948c51b4fcbf1ca4e27c26a7d75984f63488f3625c328b9b"},
-    {file = "coverage-7.7.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c124025430249118d018dcedc8b7426f39373527c845093132196f2a483b6dd"},
-    {file = "coverage-7.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e7f559c36d5cdc448ee13e7e56ed7b6b5d44a40a511d584d388a0f5d940977ba"},
-    {file = "coverage-7.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:37cbc7b0d93dfd133e33c7ec01123fbb90401dce174c3b6661d8d36fb1e30608"},
-    {file = "coverage-7.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7d2a65876274acf544703e943c010b60bd79404e3623a1e5d52b64a6e2728de5"},
-    {file = "coverage-7.7.0-cp311-cp311-win32.whl", hash = "sha256:f5a2f71d6a91238e7628f23538c26aa464d390cbdedf12ee2a7a0fb92a24482a"},
-    {file = "coverage-7.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:ae8006772c6b0fa53c33747913473e064985dac4d65f77fd2fdc6474e7cd54e4"},
-    {file = "coverage-7.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:056d3017ed67e7ddf266e6f57378ece543755a4c9231e997789ab3bd11392c94"},
-    {file = "coverage-7.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33c1394d8407e2771547583b66a85d07ed441ff8fae5a4adb4237ad39ece60db"},
-    {file = "coverage-7.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fbb7a0c3c21908520149d7751cf5b74eb9b38b54d62997b1e9b3ac19a8ee2fe"},
-    {file = "coverage-7.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb356e7ae7c2da13f404bf8f75be90f743c6df8d4607022e759f5d7d89fe83f8"},
-    {file = "coverage-7.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bce730d484038e97f27ea2dbe5d392ec5c2261f28c319a3bb266f6b213650135"},
-    {file = "coverage-7.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa4dff57fc21a575672176d5ab0ef15a927199e775c5e8a3d75162ab2b0c7705"},
-    {file = "coverage-7.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b667b91f4f714b17af2a18e220015c941d1cf8b07c17f2160033dbe1e64149f0"},
-    {file = "coverage-7.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:693d921621a0c8043bfdc61f7d4df5ea6d22165fe8b807cac21eb80dd94e4bbd"},
-    {file = "coverage-7.7.0-cp312-cp312-win32.whl", hash = "sha256:52fc89602cde411a4196c8c6894afb384f2125f34c031774f82a4f2608c59d7d"},
-    {file = "coverage-7.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ce8cf59e09d31a4915ff4c3b94c6514af4c84b22c4cc8ad7c3c546a86150a92"},
-    {file = "coverage-7.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4545485fef7a8a2d8f30e6f79ce719eb154aab7e44217eb444c1d38239af2072"},
-    {file = "coverage-7.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1393e5aa9441dafb0162c36c8506c648b89aea9565b31f6bfa351e66c11bcd82"},
-    {file = "coverage-7.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:316f29cc3392fa3912493ee4c83afa4a0e2db04ff69600711f8c03997c39baaa"},
-    {file = "coverage-7.7.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1ffde1d6bc2a92f9c9207d1ad808550873748ac2d4d923c815b866baa343b3f"},
-    {file = "coverage-7.7.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:416e2a8845eaff288f97eaf76ab40367deafb9073ffc47bf2a583f26b05e5265"},
-    {file = "coverage-7.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5efdeff5f353ed3352c04e6b318ab05c6ce9249c25ed3c2090c6e9cadda1e3b2"},
-    {file = "coverage-7.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:57f3bd0d29bf2bd9325c0ff9cc532a175110c4bf8f412c05b2405fd35745266d"},
-    {file = "coverage-7.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3ab7090f04b12dc6469882ce81244572779d3a4b67eea1c96fb9ecc8c607ef39"},
-    {file = "coverage-7.7.0-cp313-cp313-win32.whl", hash = "sha256:180e3fc68ee4dc5af8b33b6ca4e3bb8aa1abe25eedcb958ba5cff7123071af68"},
-    {file = "coverage-7.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:55143aa13c49491f5606f05b49ed88663446dce3a4d3c5d77baa4e36a16d3573"},
-    {file = "coverage-7.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:cc41374d2f27d81d6558f8a24e5c114580ffefc197fd43eabd7058182f743322"},
-    {file = "coverage-7.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:89078312f06237417adda7c021c33f80f7a6d2db8572a5f6c330d89b080061ce"},
-    {file = "coverage-7.7.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b2f144444879363ea8834cd7b6869d79ac796cb8f864b0cfdde50296cd95816"},
-    {file = "coverage-7.7.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:60e6347d1ed882b1159ffea172cb8466ee46c665af4ca397edbf10ff53e9ffaf"},
-    {file = "coverage-7.7.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb203c0afffaf1a8f5b9659a013f8f16a1b2cad3a80a8733ceedc968c0cf4c57"},
-    {file = "coverage-7.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ad0edaa97cb983d9f2ff48cadddc3e1fb09f24aa558abeb4dc9a0dbacd12cbb4"},
-    {file = "coverage-7.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:c5f8a5364fc37b2f172c26a038bc7ec4885f429de4a05fc10fdcb53fb5834c5c"},
-    {file = "coverage-7.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4e09534037933bf6eb31d804e72c52ec23219b32c1730f9152feabbd7499463"},
-    {file = "coverage-7.7.0-cp313-cp313t-win32.whl", hash = "sha256:1b336d06af14f8da5b1f391e8dec03634daf54dfcb4d1c4fb6d04c09d83cef90"},
-    {file = "coverage-7.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b54a1ee4c6f1905a436cbaa04b26626d27925a41cbc3a337e2d3ff7038187f07"},
-    {file = "coverage-7.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1c8fbce80b2b8bf135d105aa8f5b36eae0c57d702a1cc3ebdea2a6f03f6cdde5"},
-    {file = "coverage-7.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d9710521f07f526de30ccdead67e6b236fe996d214e1a7fba8b36e2ba2cd8261"},
-    {file = "coverage-7.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7789e700f33f2b133adae582c9f437523cd5db8de845774988a58c360fc88253"},
-    {file = "coverage-7.7.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c36093aca722db73633cf2359026ed7782a239eb1c6db2abcff876012dc4cf"},
-    {file = "coverage-7.7.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c075d167a6ec99b798c1fdf6e391a1d5a2d054caffe9593ba0f97e3df2c04f0e"},
-    {file = "coverage-7.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d013c07061751ae81861cae6ec3a4fe04e84781b11fd4b6b4201590234b25c7b"},
-    {file = "coverage-7.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:104bf640f408f4e115b85110047c7f27377e1a8b7ba86f7db4fa47aa49dc9a8e"},
-    {file = "coverage-7.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:39abcacd1ed54e2c33c54bdc488b310e8ef6705833f7148b6eb9a547199d375d"},
-    {file = "coverage-7.7.0-cp39-cp39-win32.whl", hash = "sha256:8e336b56301774ace6be0017ff85c3566c556d938359b61b840796a0202f805c"},
-    {file = "coverage-7.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:8c938c6ae59be67ac19a7204e079efc94b38222cd7d0269f96e45e18cddeaa59"},
-    {file = "coverage-7.7.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:3b0e6e54591ae0d7427def8a4d40fca99df6b899d10354bab73cd5609807261c"},
-    {file = "coverage-7.7.0-py3-none-any.whl", hash = "sha256:708f0a1105ef2b11c79ed54ed31f17e6325ac936501fc373f24be3e6a578146a"},
-    {file = "coverage-7.7.0.tar.gz", hash = "sha256:cd879d4646055a573775a1cec863d00c9ff8c55860f8b17f6d8eee9140c06166"},
+    {file = "coverage-7.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe"},
+    {file = "coverage-7.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f"},
+    {file = "coverage-7.8.0-cp310-cp310-win32.whl", hash = "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f"},
+    {file = "coverage-7.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9"},
+    {file = "coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c"},
+    {file = "coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe"},
+    {file = "coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545"},
+    {file = "coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3"},
+    {file = "coverage-7.8.0-cp313-cp313-win32.whl", hash = "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d"},
+    {file = "coverage-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883"},
+    {file = "coverage-7.8.0-cp313-cp313t-win32.whl", hash = "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada"},
+    {file = "coverage-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899"},
+    {file = "coverage-7.8.0-cp39-cp39-win32.whl", hash = "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f"},
+    {file = "coverage-7.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3"},
+    {file = "coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd"},
+    {file = "coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7"},
+    {file = "coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501"},
 ]
 
 [package.extras]
@@ -747,58 +747,58 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
-version = "2.39.6"
+version = "2.44.1"
 description = "A faster version of dbus-next"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "platform_system == \"Linux\""
 files = [
-    {file = "dbus_fast-2.39.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcf845a85293f9eb0da15cf2b01477608c55e1d625f2c595354290cfc46d22ca"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ea5079edf096d5cd081d8639ebc6072ddc1646aab37ca0f529021ba977ac253"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:832c6f367ab50b7365519feeef9df1dcd6f7938ecbbe5fd00f4785ab9a73ae44"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e63f493d4b941acb3b68ff3778a5259fa4d4a3a6949ebb69fe80818cd29cdf"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:af6a44bdbaaa66b8168d55d4ea04dfe6f5e14bf5da96609b74a13c78d7b4179c"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b64cf06788751c233b302001df84a8d8f4cbcea0f7d09b9892e2039f8da97b5e"},
-    {file = "dbus_fast-2.39.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:87f59a793191bc9862b8e37b997b84dd5b4c8cb4a08cd8c75c7359541d68daac"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:69d7939f2076f882f1c1be4625b80ebb1b4761622710446012c38b8161d1ec4e"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e74c62144e70a6ff2954a3ffc3c58717febd807bfa79516546232ab1fe6f601"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:91efb5f609b3bd3db5c5c3ddb22b61403d346cc8768d54243072293ba8e5dd6c"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:676e4b136b1030988a5e943f5cad70af9c9bbefc15762a71623c35d43f632340"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:868784c6feef883ee46240db4448031947789fe9f863471dbe051f3facca270a"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d0ca9ce3aa264dd38c9c8a9bde5d224563077156d32ec8dd58a78db130deed4a"},
-    {file = "dbus_fast-2.39.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:877c8e361667fe92562c85b3902ca91d16b1a53b6de9d2db11b2d7a742222a3f"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9704e2e27444e266d21d83ba4bcbf27e9666bb6274268cf20d8ea4a52404bf38"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8abd3d27da0d2d1d863059514efa094b4d488920f9458aa40c655904905150d8"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:8dca1ec19826f95838821578d1a6dddb8ff147df46b3640132db080027ab04b1"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:809c48eba60c9d593e265ee1b90d307e138c01dca14297838ce1dd9aca231fb4"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:930eaf3a8a29a166fa4940a560b5b22d2dae342d43c568cdcffeb699337deeae"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:587e38c403560986a3495eb4f162efa0690bfb8e3b8fc426976b13ad4d918400"},
-    {file = "dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1fe17820e3956b1719aacc605c19f3235d143b1c92edcf74b0416134171c5e8f"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1d2e733a31e2e3d27cbed165344f4e41136b77836a7157a1f341556fdde5e00"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6293ba84a45c91ef94ef315d9101f4fe410b27c82135f8096fca7d6549cb9288"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:c559bcf3345fe84c16d4eea99712337a6d6806a02c9f2117a143381cc07f6b47"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8408b810c43892fa2c51982c88f6e08a3cec0ce9fa486203a0fc49fbab0cb37b"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:e5d148e5724d243550230235625305782ceec73b4ef48f9e1c4b507083a1f3cb"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b134b3a91f23e11240aa81bd961a8f57d276374b76cee4fba29ea690692c15f8"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:551ee7fc981e6a65452877028c927106a216e8f9b38efbd5fcd90d4109e58fee"},
-    {file = "dbus_fast-2.39.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8472e7f4058b4dc09e8fd2cbbb8e73965095b7693c0faa0945ceab9ac9afbe9f"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b34b670477142386e78b9ab9be61fc07d0cae68b89dd8a852fed9877d15df04a"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e35fbefaa0d34e110e78a864a0eef9f771aaa24f6a6948032e79df9ac61004ae"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:c4f799b8aca6ef1b07aa73006efad214fc3ae561ac8555a03229ac0044d57505"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:030291d43f6296bd6f8d0d3f395f2a0f61bebc3a9c9ee9b1217662229d75cc48"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:11ec823935700be1abde631548b3cfe92f41894eed2e7b11c29aafd0e0d4ebd1"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c3c96d3b973374e931d2c49044aece2f4dac59647a36e7e55ed3707128c7d759"},
-    {file = "dbus_fast-2.39.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a42fa9ab6908372c7727573e27b1bfcf7edbf165bdd16fed08f9eccadeaec7ed"},
-    {file = "dbus_fast-2.39.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:44a0cd7e8373c043c45747c3fa5f3552f8e2d09f768149ef81281d39e2405dfb"},
-    {file = "dbus_fast-2.39.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:123b153f005b2b262b7ed2a7775325b60473ad12be5a059baba933fc2f3356e9"},
-    {file = "dbus_fast-2.39.6-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:58d01854bd150aadb1ca1f59f166185a24a8387b33099d97863adbc7d91b0428"},
-    {file = "dbus_fast-2.39.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c5ae45021009c6e02d4a97cb03a7fe4c4a8c9562a8442a46b0f4ac48617c433"},
-    {file = "dbus_fast-2.39.6-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:fb5fba8412f3dc8b563e629a11c495d051333c401e0fd9df1edd4fd6670f4d47"},
-    {file = "dbus_fast-2.39.6-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3187fd17e473c5eb44d773114885cfc233a7416e309d8be63bfae9f937703c2e"},
-    {file = "dbus_fast-2.39.6-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:70dc8c8bff4694f30363a7ef0cc31f32a28c901cc6e6333e5df67ff4c4072bcd"},
-    {file = "dbus_fast-2.39.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f5a85ddf4b22eb9cc729afe9c564e8e5dde5e9a50b5dab502ac15952675e84"},
-    {file = "dbus_fast-2.39.6.tar.gz", hash = "sha256:fc3349ffea522d137d856f8967129dd4b87394c0bf8b8b1648295c5eb0a457fe"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c78a004ba43aeaf203a19169d2b4be238375905645999da30cb0da730df80cf2"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65a634286651398f3f1326e8200fc54289d52c2c00249d29cacfc691660a5da1"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:0c4a128f8b29941307fc5722f37a1bb87ddcf733188d917ab374d9da0c6e1ce7"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adaf459fbce22a63d3578f3ec782c6978edf975eb06d71fb5b7a690496cf6bbe"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:de871cf722c436bdcceb96b2a3af7084e1fa468f7916ae278ec8ec49a6fa7eef"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b40863de172031bcc02f54c6f05cccb0b882dc2e1b09e11314a8ccf38c558760"},
+    {file = "dbus_fast-2.44.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8b7ae16555df6b56d3befcc51e036779ef47c0e954fdb9fb0821ac25212aefe9"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a220a28e88062a2548f0c6da9eb15fb7e3af70eae56729fc3795ce3e3fba057d"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ec5db912bd4cfeadf7134163d6dde684271cd44cf26e3b4720107f3de406623"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:6ad99f626837753b39a39e09facd2091ee4851ee1eb6ebec5fa9a9a231734254"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7aa157f689a114bfb5367c55884d35e25d57cf25202a6590ce05010f929e7df"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f961d8bcad80359f24c0156b3094f58a87d583d56139ee50922fe5894b6797cf"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1f38fb5c31846c3ada8fc2b693d8d19953d376a9ea21079e3686e93faa1f8a0f"},
+    {file = "dbus_fast-2.44.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:35e3cde53cc9180ce95c6c84a1e8d1ded429031e4a0a182606e8d22cf57d3294"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f30fb09f1ea13658fb4316511e27d6b94f8363b16f2d093efe73e6e289b740"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dd0f8d41f6ab9d4a782c116470bc319d690f9b50c97b6debc6d1fef08e4615a"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:9d6e386658343db380b9e4e81b3bf4e3c17135dbb5889173b1f2582b675b9a8c"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bd27563c11219b6fde7a5458141d860d8445c2defb036bab360d1f9bf1dfae0"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0272784aceac821dd63c8187a8860179061a850269617ff5c5bd25ca37bf9307"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:eed613a909a45f0e0a415c88b373024f007a9be56b1316812ed616d69a3b9161"},
+    {file = "dbus_fast-2.44.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0d4288f2cba4f8309dcfd9f4392e0f4f2b5be6c796dfdb0c5e03228b1ab649b1"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50a9a4c6921f4b7446717fb4869750f54b561ce486b25b36550cb2a910c988d9"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89dc5db158bf9838979f732acc39e0e1ecd7e3295a09fa8adb93b09c097615a4"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f11878c0c089d278861e48c02db8002496c2233b0f605b5630ef61f0b7fb0ea3"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd81f483b3ffb71e88478cfabccc1fab8d7154fccb1c661bfafcff9b0cfd996"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:ad499de96a991287232749c98a59f2436ed260f6fd9ad4cb3b04a4b1bbbef148"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:36c44286b11e83977cd29f9551b66b446bb6890dff04585852d975aa3a038ca2"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:89f2f6eccbb0e464b90e5a8741deb9d6a91873eeb41a8c7b963962b39eb1e0cd"},
+    {file = "dbus_fast-2.44.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bb74a227b071e1a7c517bf3a3e4a5a0a2660620084162e74f15010075534c9d5"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e3719399e687359b0ef66af1b720661dd4f12059db1c4f506e678569a2256b4"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:806450623ef3f8df846524da7e448edc8174261a01cfd5dfda92e3df89c0de10"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:55ad499b7ef08cb76fce9c9fdcdd6589d2ebfc7e53b3d261d8f40c6d97a8d901"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55d717865219ec2ae9977b6d067c05261cdc3ef6205c687c8bb92b3437886e58"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:39d4cc61e491e11912f76d70cc1c47387ab4f2e5b71f34bfa13eb11aa6026268"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9b3b10151f1140f7b6dd47a89fc37edd05d6213be0a1748eadba82fc144c05c2"},
+    {file = "dbus_fast-2.44.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:33772c223f5cef1bacc298e83dc04b27b3a47065b245fde766fcc126e761dca7"},
+    {file = "dbus_fast-2.44.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:80e3f42f982af45bcfa0ff23e808f3aa54a45fe4bf43aadd3beb5ace816fba76"},
+    {file = "dbus_fast-2.44.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f29a81d86c9ce3020a5df8c1e5557edaa00e1e00c9804ec874d46c99d967a686"},
+    {file = "dbus_fast-2.44.1-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:5dec134715457601c0fa8df3040a56d319de1a152464ae4d4bfc53bbb5c02e04"},
+    {file = "dbus_fast-2.44.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:893509b516f2f24b4e3f09a6b1f3a30f856cf237cd773cdc505ea7ab4fa3c863"},
+    {file = "dbus_fast-2.44.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:db81275d708774f6a17c89f2e063398c0deb358c4d22b663a3dd99861f6683a4"},
+    {file = "dbus_fast-2.44.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:161a3e6fc8783c30c9feb072e09604d96ec0c465b06bd35b6acc1a0316bd2a27"},
+    {file = "dbus_fast-2.44.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:67febe6454e714d85a532bd84969001ed948bbaf1699a7e1e4c6abb5508c9522"},
+    {file = "dbus_fast-2.44.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:890f0fc046d5db66524ddedeca8c14b65739fbbf32d6488175c07428362bf250"},
+    {file = "dbus_fast-2.44.1.tar.gz", hash = "sha256:b027e96c39ed5622bb54d811dcdbbe9d9d6edec3454808a85a1ceb1867d9e25c"},
 ]
 
 [[package]]
@@ -845,50 +845,50 @@ files = [
 
 [[package]]
 name = "habluetooth"
-version = "3.36.0"
+version = "3.38.0"
 description = "High availability Bluetooth"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "habluetooth-3.36.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f7a9495e5a8c55b218cae007be7950f823d6097b0bd0db16f3353aeea03e9f84"},
-    {file = "habluetooth-3.36.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2612b38f3660e82d67ab8363f75112de47120909d1ffdf552c1678ff03bb8af7"},
-    {file = "habluetooth-3.36.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58730782e1fedbc3fc188397a6916d517be5d283bd97e44543fd780a7e33320e"},
-    {file = "habluetooth-3.36.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:03b82c17f5a49f01d1c6927e57f2c8f593cd040a94fc049a2250c94ec03ef0da"},
-    {file = "habluetooth-3.36.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aa2455cae930f6a8bbc1a461a025fa68d6cd8e1b55ae34908554a3941c4dc9"},
-    {file = "habluetooth-3.36.0-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8578d106d641d5655640d1ea5357827f374990dd750387b12e040c754e134a8a"},
-    {file = "habluetooth-3.36.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:217323be638381ad40942bc55581e809ba73dfb0e7e1808595837867c4dfe33a"},
-    {file = "habluetooth-3.36.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5f7670d73ba08306508f849bccfc4f816d59d637096c8d6dd6d5fc223e8dbc3e"},
-    {file = "habluetooth-3.36.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:78e730559e073297904f32165c322d83cd0261419d20ea1adda5a406880db17a"},
-    {file = "habluetooth-3.36.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0886c3533d3d9bf8130ba4e21cfe3930da2ab5ddd9991aaae2afe207ec576d66"},
-    {file = "habluetooth-3.36.0-cp311-cp311-win32.whl", hash = "sha256:ed8f0f47d300a091724238d1669e7f98820ec8cc36c4819d6e0e6a0a2ed8bb22"},
-    {file = "habluetooth-3.36.0-cp311-cp311-win_amd64.whl", hash = "sha256:1b9cf33f81bd31388e2d29d90aeca87f0145e5e3754f19f8b3aca6c15eba3ac8"},
-    {file = "habluetooth-3.36.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:62c4f5fa4c817c1e60cd88d10a1893c70a49e5b446d30f503451a339deec51d4"},
-    {file = "habluetooth-3.36.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9fa2c4e0dbe5104d5532c1428979571df56a160831086256d538a13983b7f683"},
-    {file = "habluetooth-3.36.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2210cbb4c7c2b5ca48ef0b6238a72a0c02e4e7ef868d1395dc5346ff37b4df4"},
-    {file = "habluetooth-3.36.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:da1158cf55fcb1f512d1ad746dca94eca515f74d3c9d97def268eede927f5836"},
-    {file = "habluetooth-3.36.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9658a74ac6d724f217e42e73dea74717a4a50b91a0553ec41cc05595b472059"},
-    {file = "habluetooth-3.36.0-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ecf0d81ca1056229ade4d62a04b96058860c3dd974e06cd37c93f0fc2e750816"},
-    {file = "habluetooth-3.36.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:219726e3e8c9b7a5539124bfa46219611574ce360552b7d01984bf20ac43f195"},
-    {file = "habluetooth-3.36.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:fa51d346bea967c71c0c3729fa53dea3246ae02efec2412ced9b6a2bee339b13"},
-    {file = "habluetooth-3.36.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c8e56b27dc14ee9fafaea727e1e4d1718e69e27cd8e4e4541efa5ff8d3f5cbaf"},
-    {file = "habluetooth-3.36.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:52fd346bbfc45fcd184c57302352d732247b91ac6e0758eafaf4dfadc86403d3"},
-    {file = "habluetooth-3.36.0-cp312-cp312-win32.whl", hash = "sha256:8cec97626bc3fcb52516872ce45a90da45a28a6a956bd2325db373206fd025f3"},
-    {file = "habluetooth-3.36.0-cp312-cp312-win_amd64.whl", hash = "sha256:bb8524e698ae9bee322a72c361556ec23181b18624014116900145701130cf97"},
-    {file = "habluetooth-3.36.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d3a0dbf028c0d7dc1861b7d0c577cabac593543c96857db6ba30f635ba2e488"},
-    {file = "habluetooth-3.36.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6dbed54bc474858af9afe838fd624ddcc4878e464fcb416024d204d22d1e53b"},
-    {file = "habluetooth-3.36.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cd35d60a374cceb8ec070481db0ec642306cae5851e35dc22e652dd8af17c97"},
-    {file = "habluetooth-3.36.0-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:c465db5f8de5b5ddc2176222c12c1eeb5cab7dac28ad0ed483b57f17818c40e5"},
-    {file = "habluetooth-3.36.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8da4a37294cfa53ce83ec767bf06f491dd5cc6ed81889e63e3d52b0110d2393"},
-    {file = "habluetooth-3.36.0-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4b97df5c8f3e31b03175655362c4e1e997d20330fa9963231218663fa8a4d461"},
-    {file = "habluetooth-3.36.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:5b08ce8ac386099844ad50a6b38979eac1cf1cf5416c92992ffb796030be435f"},
-    {file = "habluetooth-3.36.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c191c519578a65649997e533415a0ae854d4e5ff3cda268379c125dd23fadb0f"},
-    {file = "habluetooth-3.36.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:beff074e91496e59739f6bfa14845a83d70a7a855fe9c2dd82a4c3500acacdeb"},
-    {file = "habluetooth-3.36.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:dfc75f1b8f8a6ac6d2e0e09a56dd1fded0eff1146287343ff55a601e9f27734f"},
-    {file = "habluetooth-3.36.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9afa829c8d1aa2f53d1a143fa02dfb34d402f0b2a89384502b8572528354e9b3"},
-    {file = "habluetooth-3.36.0-cp313-cp313-win32.whl", hash = "sha256:0a359938b6cd0b475c0d6ebf79aa3950e0b49be61598e150f0505624b905ff07"},
-    {file = "habluetooth-3.36.0-cp313-cp313-win_amd64.whl", hash = "sha256:f17fa171faa7ba026243e0edfbf50227df7956365062c55e7505406ae4acd454"},
-    {file = "habluetooth-3.36.0.tar.gz", hash = "sha256:347c62e033759497b50b3a9e7f36c59d95a14f4460a44ecd4d2e4fd232613c61"},
+    {file = "habluetooth-3.38.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1881c146d5b84c5a1f07fe0113281166d35be19ab1cc08ce3f9ace19af165ef3"},
+    {file = "habluetooth-3.38.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:07561287ea6afab873678c60b5d592b515add1ddee0d9a7564f97e55e3778d50"},
+    {file = "habluetooth-3.38.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb1909b53d5906fca6a6f88e08f27430d565f5abacdcd983882133e4fca2840e"},
+    {file = "habluetooth-3.38.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:9d406429a193ace0d8d5ab0e6d322aa51b793455f2d03a26ba738ee47b710c55"},
+    {file = "habluetooth-3.38.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2401d83a0c6dee999d514722b9373a733525abec148a90be6a20bd0e56cbfaf8"},
+    {file = "habluetooth-3.38.0-cp311-cp311-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:810dcdf4cf2cad298d9200c5aaa0332b42719230de91d810ce82f98aed58ceea"},
+    {file = "habluetooth-3.38.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0ec7afd0ea2a5af6cccb87834836dfcf55354c80e13613d3ae29e126123f09ac"},
+    {file = "habluetooth-3.38.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3490ccc601dfb717318b2d1251a289e8578bc9e42df4534e57e7c2d08c3947e5"},
+    {file = "habluetooth-3.38.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9376f819578edcf44a4d352c9ace7e7f42ab7560b13024442dd07f2abb887016"},
+    {file = "habluetooth-3.38.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b169edba40de9d4b29178320409da9137c2d348b7e89df7eae4f37aff32b92e7"},
+    {file = "habluetooth-3.38.0-cp311-cp311-win32.whl", hash = "sha256:b852744e6303f25eeec4673d4e9ab62e9abfa2e945d35388aa28b45eb9702b10"},
+    {file = "habluetooth-3.38.0-cp311-cp311-win_amd64.whl", hash = "sha256:a38824ed6e92409ace2de3e345f5e78b38bc853a5ee5af986ba30ed80441adc2"},
+    {file = "habluetooth-3.38.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1545bfd35a1286dff9737cd0273b2db0d2cdaa2794d3e13de39822204fd6783f"},
+    {file = "habluetooth-3.38.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:338405eff410edfd2053014191a9389401e7d8db3da74f962a83d07ce0202617"},
+    {file = "habluetooth-3.38.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a01ac6c678a596771ec2a626ca0e1bbc84f1b92d449a56dbdbd1c5dfd1affba6"},
+    {file = "habluetooth-3.38.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:6b34afda7868e9af8150271de129a66d4fdeadbf654c8c99ab8465ed574e436f"},
+    {file = "habluetooth-3.38.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2c122801406546764e23e26d211940cfaeec5abddbc7276b4bad264211797b2"},
+    {file = "habluetooth-3.38.0-cp312-cp312-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f18ed561187e1ad4789364cb45d8de196b8b7701e45a2817db85ef304dcbb2d6"},
+    {file = "habluetooth-3.38.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d08b029a99eb97025eb79c6c91202315d48e72fe65b2066cfe4079ece0527248"},
+    {file = "habluetooth-3.38.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:710da6a6493cfeb154b70d6316abe5b200ad030cd458c71ffd58fba02e5117b1"},
+    {file = "habluetooth-3.38.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c2fdfcb075ef1b548f1af1b13a471c7d3a782696d645147571196062599e77c"},
+    {file = "habluetooth-3.38.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1061f6bdce4d80e884065dbf0a963c2dd3311d5c28d5c30f3ae99c126c2aa1e"},
+    {file = "habluetooth-3.38.0-cp312-cp312-win32.whl", hash = "sha256:cdf4c70adb903f233735bb64f3fffe00809e209489178ac26065eb403e0cf299"},
+    {file = "habluetooth-3.38.0-cp312-cp312-win_amd64.whl", hash = "sha256:e1d8feb52a26ab5746422ff7474afd20f0908676ec5d3c117a4e000a1a6f624e"},
+    {file = "habluetooth-3.38.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2fad8f120aa7ea60bb0cc5813e9bca7cf71aa73bad0c4963329ce6061a586a3a"},
+    {file = "habluetooth-3.38.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be3d47624e24f041f51f2f27a7c12e4c668d10babe4e5e405fa95e99cd7643b4"},
+    {file = "habluetooth-3.38.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75bab83183932cf72ba1022a59f89a7ab38ff1eb89976a3ad69632f2152b31ab"},
+    {file = "habluetooth-3.38.0-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:7bb74e4806282560fd59d069824af5665656daed64bc7b732387d523f44b0c4e"},
+    {file = "habluetooth-3.38.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b87c68c439999b1f47a686334633c75d5885cecb6863ef824331d1ba29c684c"},
+    {file = "habluetooth-3.38.0-cp313-cp313-manylinux_2_31_armv7l.manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:677137a00cbb1fad58f9201fdad16b6d16b9fc9f11556db2ed6fe3013e717656"},
+    {file = "habluetooth-3.38.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:6a382b10467262326f3944c0822d61d3ebef8f4587fd256cf9567f8b553225f5"},
+    {file = "habluetooth-3.38.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8c53ccec8a747d5488f52eb7b415482d584a1025b4c228f410b04fd8da535db7"},
+    {file = "habluetooth-3.38.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:a8919c1b84969ea906e586e68c2e36880be652263a16f343ccaf16ba6b47d4d6"},
+    {file = "habluetooth-3.38.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3f9ad0b37c3b05c67621e7e0321d40628f1955c3ada0dbdb46180d0b60e1855e"},
+    {file = "habluetooth-3.38.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2c1aad5ad0e04504a710b3d75be1ee49d9629d42dc7e454830699245c1872a1f"},
+    {file = "habluetooth-3.38.0-cp313-cp313-win32.whl", hash = "sha256:4f4adfd4ea2acb669f6cfef7dbccb4ea4ed0892850c0d312de9197f3dc559109"},
+    {file = "habluetooth-3.38.0-cp313-cp313-win_amd64.whl", hash = "sha256:4881c9e0c497441a8ac392c9b6236ae1ac01af94ffbcb038436b8157ec43a571"},
+    {file = "habluetooth-3.38.0.tar.gz", hash = "sha256:1a191bf48373edfb8e476acd6a79f756a1de3aafc78210a96271e9e32f6b5131"},
 ]
 
 [package.dependencies]
@@ -1262,21 +1262,21 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "6.30.1"
+version = "6.30.2"
 description = ""
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "protobuf-6.30.1-cp310-abi3-win32.whl", hash = "sha256:ba0706f948d0195f5cac504da156d88174e03218d9364ab40d903788c1903d7e"},
-    {file = "protobuf-6.30.1-cp310-abi3-win_amd64.whl", hash = "sha256:ed484f9ddd47f0f1bf0648806cccdb4fe2fb6b19820f9b79a5adf5dcfd1b8c5f"},
-    {file = "protobuf-6.30.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aa4f7dfaed0d840b03d08d14bfdb41348feaee06a828a8c455698234135b4075"},
-    {file = "protobuf-6.30.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:47cd320b7db63e8c9ac35f5596ea1c1e61491d8a8eb6d8b45edc44760b53a4f6"},
-    {file = "protobuf-6.30.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3083660225fa94748ac2e407f09a899e6a28bf9c0e70c75def8d15706bf85fc"},
-    {file = "protobuf-6.30.1-cp39-cp39-win32.whl", hash = "sha256:554d7e61cce2aa4c63ca27328f757a9f3867bce8ec213bf09096a8d16bcdcb6a"},
-    {file = "protobuf-6.30.1-cp39-cp39-win_amd64.whl", hash = "sha256:b510f55ce60f84dc7febc619b47215b900466e3555ab8cb1ba42deb4496d6cc0"},
-    {file = "protobuf-6.30.1-py3-none-any.whl", hash = "sha256:3c25e51e1359f1f5fa3b298faa6016e650d148f214db2e47671131b9063c53be"},
-    {file = "protobuf-6.30.1.tar.gz", hash = "sha256:535fb4e44d0236893d5cf1263a0f706f1160b689a7ab962e9da8a9ce4050b780"},
+    {file = "protobuf-6.30.2-cp310-abi3-win32.whl", hash = "sha256:b12ef7df7b9329886e66404bef5e9ce6a26b54069d7f7436a0853ccdeb91c103"},
+    {file = "protobuf-6.30.2-cp310-abi3-win_amd64.whl", hash = "sha256:7653c99774f73fe6b9301b87da52af0e69783a2e371e8b599b3e9cb4da4b12b9"},
+    {file = "protobuf-6.30.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:0eb523c550a66a09a0c20f86dd554afbf4d32b02af34ae53d93268c1f73bc65b"},
+    {file = "protobuf-6.30.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:50f32cc9fd9cb09c783ebc275611b4f19dfdfb68d1ee55d2f0c7fa040df96815"},
+    {file = "protobuf-6.30.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4f6c687ae8efae6cf6093389a596548214467778146b7245e886f35e1485315d"},
+    {file = "protobuf-6.30.2-cp39-cp39-win32.whl", hash = "sha256:524afedc03b31b15586ca7f64d877a98b184f007180ce25183d1a5cb230ee72b"},
+    {file = "protobuf-6.30.2-cp39-cp39-win_amd64.whl", hash = "sha256:acec579c39c88bd8fbbacab1b8052c793efe83a0a5bd99db4a31423a25c0a0e2"},
+    {file = "protobuf-6.30.2-py3-none-any.whl", hash = "sha256:ae86b030e69a98e08c77beab574cbcb9fff6d031d57209f574a5aea1445f4b51"},
+    {file = "protobuf-6.30.2.tar.gz", hash = "sha256:35c859ae076d8c56054c25b59e5e59638d86545ed6e2b6efac6be0b6ea3ba048"},
 ]
 
 [[package]]
@@ -1480,14 +1480,14 @@ test = ["pytest (>=7.0,<8.0)", "pytest-cov (>=4.0.0,<4.1.0)"]
 
 [[package]]
 name = "pytest-cov"
-version = "6.0.0"
+version = "6.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
-    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
+    {file = "pytest_cov-6.1.0-py3-none-any.whl", hash = "sha256:cd7e1d54981d5185ef2b8d64b50172ce97e6f357e6df5cb103e828c7f993e201"},
+    {file = "pytest_cov-6.1.0.tar.gz", hash = "sha256:ec55e828c66755e5b74a21bd7cc03c303a9f928389c0563e50ba454a6dbe71db"},
 ]
 
 [package.dependencies]
@@ -1584,14 +1584,14 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "14.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["dev"]
 files = [
-    {file = "rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"},
-    {file = "rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098"},
+    {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
+    {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
 ]
 
 [package.dependencies]
@@ -1850,14 +1850,14 @@ full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart 
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.1"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "docs"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69"},
+    {file = "typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff"},
 ]
 markers = {main = "python_version < \"3.12\""}
 


### PR DESCRIPTION
  - Updating bleak-retry-connector (3.9.0 -> 3.10.0)
  - Updating bluetooth-data-tools (1.26.1 -> 1.27.0)
  - Updating coverage (7.7.0 -> 7.8.0)
  - Updating protobuf (6.30.1 -> 6.30.2)
  - Updating rich (13.9.4 -> 14.0.0)
  - Updating aioesphomeapi (29.7.0 -> 29.8.0)
  - Updating habluetooth (3.36.0 -> 3.38.0)
  - Updating pytest-cov (6.0.0 -> 6.1.0)

dependabot does not support newer pyproject.toml format at this time so we must do it manually