### PR TITLE
fix: disable 32bit wheels on linux to fix builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         env:
           CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
           REQUIRE_CYTHON: 1
-          CIBW_ARCHS_LINUX: ${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'auto' }}
+          CIBW_ARCHS_LINUX: ${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'auto64' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,3 @@ ignore_errors = true
 [build-system]
 requires = ['setuptools>=75.8.2', 'Cython>=3', "poetry-core>=2.0.0", "habluetooth"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.cibuildwheel.linux]
-archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,3 +162,6 @@ ignore_errors = true
 [build-system]
 requires = ['setuptools>=75.8.2', 'Cython>=3', "poetry-core>=2.0.0", "habluetooth"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.cibuildwheel.linux]
+archs = ["auto64"]


### PR DESCRIPTION
cryptography does not ship 32bit wheels on linux anymore
so it makes building this package harder