### PR TITLE
fix: revert to using Python API for scanner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,5 +160,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=75.8.2', 'Cython>=3', "poetry-core>=2.0.0", "habluetooth"]
+requires = ['setuptools>=75.8.2', 'Cython>=3', "poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/bleak_esphome/backend/scanner.pxd
+++ b/src/bleak_esphome/backend/scanner.pxd
@@ -1,9 +1,5 @@
 
-from habluetooth.base_scanner cimport BaseHaRemoteScanner
 
 cdef object MONOTONIC_TIME
 cdef object int_to_bluetooth_address
 cdef object parse_advertisement_data_tuple
-
-cdef class ESPHomeScanner(BaseHaRemoteScanner):
-    pass

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -45,9 +45,10 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         # To work around this we use a for loop to iterate over
         # the repeated field since `PyUpb_RepeatedContainer_Subscript`
         # does not trigger the debug logging.
+        on_raw = self._async_on_raw_advertisement
         for i in range(len(advertisements)):
             adv = advertisements[i]
-            self._async_on_raw_advertisement(
+            on_raw(
                 int_to_bluetooth_address(adv.address),
                 adv.rssi,
                 adv.data,


### PR DESCRIPTION
We have had too many ABI compat issues so we need
to go back to the Python API