### PR TITLE
feat: use set_*_mode helpers instead of setting mode directly

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -845,66 +845,20 @@ files = [
 
 [[package]]
 name = "habluetooth"
-version = "5.0.2"
+version = "5.2.0"
 description = "High availability Bluetooth"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "habluetooth-5.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c9f3ca2eea812df8ecc9da728fb996b579c2c1db022e0bb1c19a08f105834bd"},
-    {file = "habluetooth-5.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:08b86cd54081ad15760bb70ce0c94b17ed7d18ee59ad75f7434bf751649268f5"},
-    {file = "habluetooth-5.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e02a99ffc876c20d301a9ed2af9d2f5d904c1cb2b27f0a45f6111092d923fd2"},
-    {file = "habluetooth-5.0.2-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e32ef2a058369a63be40a55a9c7f248bce056baf1cd4010e6e04f3b2488b2387"},
-    {file = "habluetooth-5.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91bfb38a466877069e2972e0d6acd4e6229b2b01e52500a12f45c1aff0e85d42"},
-    {file = "habluetooth-5.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2e048ba2e6d63f7e1896b7fbbcb92956585083ed6149f304bb5f476578107ece"},
-    {file = "habluetooth-5.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6ec1e49e60ba9ffa4991079394f9e42b070cd71dffff65bcfe11e8c16a625b5a"},
-    {file = "habluetooth-5.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:75d02bee3cf31df664116dbf24faecb23c98c70ff00025c295e0808c07a5064c"},
-    {file = "habluetooth-5.0.2-cp311-cp311-win32.whl", hash = "sha256:aa9023665068f6c2d93be441107b6a64fff4e051f4a3427317a88f4786833fbd"},
-    {file = "habluetooth-5.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:8a07aa6ce9ebeb9e0a1ec0fa91962da1cde450beae8350519ebf6903c734b237"},
-    {file = "habluetooth-5.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bf6db5edd8fa21c329dd1e3c25a1c5eb34d6fe0b50d05de1cdde5941d5f50b9"},
-    {file = "habluetooth-5.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03d9cdee10464d99e20e39b823c5678c9d2148c5e3f378439673395d53ccc1b4"},
-    {file = "habluetooth-5.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77690ac7481373e5490b3ab8b66e8e4596c9f4483dea88627ad86490f05ffdd7"},
-    {file = "habluetooth-5.0.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:be248ef832d0528c727ef6f5c7d696a7137c449e1f80c89e67e89edb11494727"},
-    {file = "habluetooth-5.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a31ca9a79097f43ce5e92be16ba5864bb855f7f603663756e02fe84f999e59f6"},
-    {file = "habluetooth-5.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:517f1e468b611e39e0cec9063dcd75462b49ac3d4b7e9a24d8edbeafa324f875"},
-    {file = "habluetooth-5.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:f5cae885828395fe7df2b2db638f5da8167c2d428405bcc9a5b3cfb60532fae8"},
-    {file = "habluetooth-5.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5ed315b7d7c60ae6b40e0c20371df7b310fef39caf9898a7e4823b4d23b9df6"},
-    {file = "habluetooth-5.0.2-cp312-cp312-win32.whl", hash = "sha256:e6904f8355d561bf2ac348dfd4d38a8742eed1f2c3dd09282d7bcebcc64bb578"},
-    {file = "habluetooth-5.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a2fb83354fab279e71996ad27cb37d0eae31531582e04c7439ba822cadd1ff4d"},
-    {file = "habluetooth-5.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a81a3208c8393f680026f99039bdf257c25ce0b4409116aa3cd6db0df360636"},
-    {file = "habluetooth-5.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:447a4ff1f147eb6a2d617e642c36ec7b63fdff47949a6da8ba5912836e96163e"},
-    {file = "habluetooth-5.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:427d7de0a462be57984931d45bb24362486d4d4464bab53031c6a445667abb4a"},
-    {file = "habluetooth-5.0.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8d6e23f2daebffbf5f184329cf5aa8061a6fef8c85cb12bfe33bc10615874002"},
-    {file = "habluetooth-5.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9333cfa923607740c6ca09c22190fb7976455400e7780fd84c1476fc7875edb0"},
-    {file = "habluetooth-5.0.2-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:fb69ee485216428a6ae4281b18c8e502b08e5326d7c56681dd183627faa77f7d"},
-    {file = "habluetooth-5.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7273bcf783fa33719bf94554352f6d14d49ed2419653006377c476011a82faf"},
-    {file = "habluetooth-5.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:98175130ef029c0ae69b3752aa6c52a550d845eeb0a2ea9e0cfdfb87873203ce"},
-    {file = "habluetooth-5.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8686616e94161ad18ef0de0944737a20247e155771f137124dd346c9104c125c"},
-    {file = "habluetooth-5.0.2-cp313-cp313-win32.whl", hash = "sha256:b73eefcc5368d6788cfbb4b5dda4a31411c42b54e3c56c843ecd3aab991c0835"},
-    {file = "habluetooth-5.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e838ff97931a2e6e244f4b3d2021e027897ce74fb295167f788c421afc9e1dac"},
-    {file = "habluetooth-5.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:751b1e371ff94174d809918fa5b8d3ddb2b6e91372235c7f08334f7411c716b2"},
-    {file = "habluetooth-5.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2556aeb71733242f4706b38df1c9f0c66b92cd5c6faf320d58fbad4f366d0987"},
-    {file = "habluetooth-5.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f733f4dcfd1b2d7fd54ea78a52804cbf33f9c7f5a3efd7de3e096cd1d594730"},
-    {file = "habluetooth-5.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5463c47a09778df6c9ce680fa722001c9752da34a8c6a60ada74cc7e660eab43"},
-    {file = "habluetooth-5.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:11ad4728ccbca5e0f244fe9b0e2e40be4380a52f0ac7300355b05da8c18d1eb8"},
-    {file = "habluetooth-5.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc526fe42d18020dd0ff03f919dfb31dc424d236ec7e0d6da80d7605ebac8f87"},
-    {file = "habluetooth-5.0.2-cp314-cp314-win32.whl", hash = "sha256:3bafee45e118c8e19627db19a96462b4948d4e037bcc2440a9d8c0a156faa7d0"},
-    {file = "habluetooth-5.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:68ede9659af308134aa8dc07d1e8d3391ffc1bdad1ef01e1f1fe1b9d1a92dd6f"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9d270971d7693c079b4f7860cb26e2732ba5cc9640e50ca5ed119a6715e51741"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b137ba27e587406b6a8708518cca85980b06530391f8aa4581ed51e5d9028dd4"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb6fda8f3929e1b718d2fb1d131705283cc493f97e5fbad26e3e59348bf53fbc"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7f57c1905d289e7d825e625218764bf479aaca8cceced95d0500e34da1a0d6f1"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:811f162eb85ab8b309ee549f3c77979490d0665e449c2b39112921fd18379aa5"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d1fd9fc9c7d8be19ac43420ec5e8d20b20a7291d62d715750f408f94843ebaa"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-win32.whl", hash = "sha256:34483ebb42b0a8e0aaf07b060ca261d5afc962b320fc11d813508ffd678377b9"},
-    {file = "habluetooth-5.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7a97d6e007e03390139f2b4bb893ea5b046404a7c2557c8efe48fd9f74de43d0"},
-    {file = "habluetooth-5.0.2.tar.gz", hash = "sha256:b7ffe65c28644f21e5118e31be9fb7b958e89355f57369853ff61a18fda37a2a"},
+    {file = "habluetooth-5.2.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:33a00ce164c3df4ba3489b873cd1a8b45e374d6d02f76416ab57285a6f2f60aa"},
+    {file = "habluetooth-5.2.0.tar.gz", hash = "sha256:00d6284d560d8afed342c825b3a2a8d97f962e499ed5aed69b8ed279e6300144"},
 ]
 
 [package.dependencies]
 async-interrupt = ">=1.1.1"
 bleak = ">=1.0.1"
-bleak-retry-connector = ">=4"
+bleak-retry-connector = ">=4.2.0"
 bluetooth-adapters = ">=2"
 bluetooth-auto-recovery = ">=1.5.1"
 bluetooth-data-tools = ">=1.28.0"
@@ -2457,4 +2411,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "f08974695f7854ae9b9e715f245eef3ade21ce4109937743c3acdd040653f979"
+content-hash = "95004498d225b572662d4b81002d2c5cbda245c24daa9cb64b5c57a7e9a55e01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ python = ">=3.11,<3.14"
 aioesphomeapi = ">=30.1.0"
 bleak = ">=1"
 bluetooth-data-tools = ">=1.18.0"
-habluetooth = ">=4"
+habluetooth = ">=5.2.0"
 lru-dict = ">=1.2.0"
 bleak-retry-connector = ">=3.8.0"
 

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -26,14 +26,14 @@ class ESPHomeScanner(BaseHaRemoteScanner):
     def async_update_scanner_state(self, state: BluetoothScannerStateResponse) -> None:
         """Update the scanner state."""
         if state.mode == BluetoothScannerMode.ACTIVE:
-            self.current_mode = BluetoothScanningMode.ACTIVE  # type: ignore[misc]
-            self.requested_mode = BluetoothScanningMode.ACTIVE  # type: ignore[misc]
+            self.set_requested_mode(BluetoothScanningMode.ACTIVE)
+            self.set_current_mode(BluetoothScanningMode.ACTIVE)
         elif state.mode == BluetoothScannerMode.PASSIVE:
-            self.current_mode = BluetoothScanningMode.PASSIVE
-            self.requested_mode = BluetoothScanningMode.PASSIVE
+            self.set_requested_mode(BluetoothScanningMode.PASSIVE)
+            self.set_current_mode(BluetoothScanningMode.PASSIVE)
         else:
-            self.current_mode = None
-            self.requested_mode = None
+            self.set_current_mode(None)
+            self.set_requested_mode(None)
 
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:
         """Call the registered callback."""


### PR DESCRIPTION
This ensures callbacks are fired from habluetooth