### PR TITLE
feat: add support for bleak 2.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -223,14 +223,14 @@ lxml = ["lxml"]
 
 [[package]]
 name = "bleak"
-version = "2.0.0"
+version = "2.1.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bleak-2.0.0-py3-none-any.whl", hash = "sha256:a4ee68ab98b0d39eb3b2a937b2f95b93123258f301b0d0087edc4529809c77b1"},
-    {file = "bleak-2.0.0.tar.gz", hash = "sha256:a8043fc0f3af1a00a84963824195463ca39789ae4f6804d3d7b1423e6083254a"},
+    {file = "bleak-2.1.1-py3-none-any.whl", hash = "sha256:61ac1925073b580c896a92a8c404088c5e5ec9dc3c5bd6fc17554a15779d83de"},
+    {file = "bleak-2.1.1.tar.gz", hash = "sha256:4600cc5852f2392ce886547e127623f188e689489c5946d422172adf80635cf9"},
 ]
 
 [package.dependencies]

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -48,6 +48,7 @@ GATT_HEADER_SIZE = 3
 DISCONNECT_TIMEOUT = 5.0
 CONNECT_FREE_SLOT_TIMEOUT = 2.0
 GATT_READ_TIMEOUT = 30.0
+DEFAULT_TIMEOUT = 30.0
 
 # CCCD (Characteristic Client Config Descriptor)
 CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
@@ -137,6 +138,8 @@ class ESPHomeClient(BaseBleakClient):
         self._disconnect_callbacks = client_data.disconnect_callbacks
         if TYPE_CHECKING:
             assert isinstance(address_or_ble_device, BLEDevice)
+        # Bleak 2.1+ requires timeout in kwargs
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         super().__init__(address_or_ble_device, *args, **kwargs)
         self._loop = asyncio.get_running_loop()
         ble_device = address_or_ble_device


### PR DESCRIPTION
## Summary

Bleak 2.1.1 changed `BaseBleakClient.__init__` to require `timeout` in kwargs instead of providing a default. This adds `DEFAULT_TIMEOUT = 30.0` and ensures it's always passed to the parent class.

Uses `setdefault()` to remain backwards compatible with older bleak versions.

## Changes

- Added `DEFAULT_TIMEOUT` constant (30.0s to match bleak 2.1.1 default)
- Set default timeout in `ESPHomeClient.__init__` before calling `super()`
