### PR TITLE
feat: allow custom GATT read timeouts

### DIFF
--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -524,7 +524,8 @@ class ESPHomeClient(BaseBleakClient):
         Args:
         ----
             characteristic: The BleakGATTCharacteristic to read from.
-            **kwargs: Unused
+            **kwargs:
+                timeout (float): Read timeout in seconds. Defaults to 30.0.
 
         Returns:
         -------
@@ -532,8 +533,9 @@ class ESPHomeClient(BaseBleakClient):
 
         """
         self._raise_if_not_connected()
+        timeout = kwargs.get("timeout", GATT_READ_TIMEOUT)
         return await self._client.bluetooth_gatt_read(
-            self._address_as_int, characteristic.handle, GATT_READ_TIMEOUT
+            self._address_as_int, characteristic.handle, timeout
         )
 
     @api_error_as_bleak_error
@@ -546,7 +548,8 @@ class ESPHomeClient(BaseBleakClient):
         Args:
         ----
             descriptor: The BleakGATTDescriptor to read from.
-            **kwargs: Unused
+            **kwargs:
+                timeout (float): Read timeout in seconds. Defaults to 30.0.
 
         Returns:
         -------
@@ -554,8 +557,9 @@ class ESPHomeClient(BaseBleakClient):
 
         """
         self._raise_if_not_connected()
+        timeout = kwargs.get("timeout", GATT_READ_TIMEOUT)
         return await self._client.bluetooth_gatt_read_descriptor(
-            self._address_as_int, descriptor.handle, GATT_READ_TIMEOUT
+            self._address_as_int, descriptor.handle, timeout
         )
 
     @api_error_as_bleak_error


### PR DESCRIPTION
This pr adds an optional timeout arg to read_gatt_char() and read_gatt_descriptor() to allow specifying longer (or shorter) timeouts for devices that have specific needs. This doesnt change the default timeout tho

Some BLE devices respond really slowly to GATT read requests and therefore need a higher timeout value, especially running through an esphome proxy

## How to use this?
```python
from bleak import BleakClient

async with BleakClient(device) as client:
    # Pass timeout as kwarg - bleak-esphome backend will use it
    data = await client.read_gatt_char(char_uuid, timeout=60.0)
```

The bleak client doesnt explicitly pass this arg but it does pass kwargs https://github.com/hbldh/bleak/blob/2d888651b802d2082edf94c786aaee8ae1dc17ba/bleak/__init__.py#L721-L723