### PR TITLE
chore(deps): bump aioesphomeapi minimum to >=44.3.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2686,4 +2686,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "1e0f3668290502468d83def7f93778184e4e8369a1c4c12f05177f6c2b3787da"
+content-hash = "cf6663c95ff8ef8015093bfc9b7bb1231c9d005da4b36a214b54e49d81cb9387"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ script = "build_ext.py"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.15"
-aioesphomeapi = ">=43.14.0"
+aioesphomeapi = ">=44.3.1"
 bleak = ">=1"
 bluetooth-data-tools = ">=1.18.0"
 habluetooth = ">=5.7.0"


### PR DESCRIPTION
## Summary

- Bumps the minimum `aioesphomeapi` version from `>=43.14.0` to `>=44.3.1`
- Updates `poetry.lock` to reflect the new constraint

## Test plan

- [x] CI passes with the updated dependency