### PR TITLE
fix: warn when ESPHome device does not support connection params

### DIFF
--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -528,9 +528,10 @@ class ESPHomeClient(BaseBleakClient):
             & BluetoothProxyFeature.CONNECTION_PARAMS_SETTING.value
         ):
             _LOGGER.warning(
-                "Setting connection parameters is not available with this"
-                " ESPHome version; Upgrade the ESPHome version on the"
-                " device %s",
+                "Setting connection parameters is not available with"
+                " ESPHome version %s on device %s;"
+                " Upgrade the ESPHome version on the device",
+                self._device_info.esphome_version,
                 self._device_info.name,
             )
             return

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -527,9 +527,11 @@ class ESPHomeClient(BaseBleakClient):
             not self._feature_flags
             & BluetoothProxyFeature.CONNECTION_PARAMS_SETTING.value
         ):
-            _LOGGER.debug(
-                "%s: ESPHome device does not support connection params setting",
-                self._description,
+            _LOGGER.warning(
+                "Setting connection parameters is not available with this"
+                " ESPHome version; Upgrade the ESPHome version on the"
+                " device %s",
+                self._device_info.name,
             )
             return
         self._raise_if_not_connected()


### PR DESCRIPTION
## Summary

- Change log level from `debug` to `warning` when the ESPHome proxy firmware does not support setting BLE connection parameters
- Matches the existing pattern used by `clear_cache()` which also warns users to upgrade their ESPHome firmware

## Test plan

- [x] Existing `test_set_connection_params_not_supported` passes