### PR TITLE
perf: cache address_type details dicts to avoid per-advertisement allocation

### DIFF
--- a/src/bleak_esphome/backend/scanner.pxd
+++ b/src/bleak_esphome/backend/scanner.pxd
@@ -3,3 +3,4 @@
 cdef object MONOTONIC_TIME
 cdef object int_to_bluetooth_address
 cdef object parse_advertisement_data_tuple
+cdef dict _ADDRESS_TYPE_CACHE

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -23,6 +23,14 @@ if TYPE_CHECKING:
     from .device import ESPHomeBluetoothDevice
 
 
+_ADDRESS_TYPE_0 = {"address_type": 0}
+_ADDRESS_TYPE_1 = {"address_type": 1}
+_ADDRESS_TYPE_CACHE: dict[int, dict[str, int]] = {
+    0: _ADDRESS_TYPE_0,
+    1: _ADDRESS_TYPE_1,
+}
+
+
 class ESPHomeScanner(BaseHaRemoteScanner):
     """Scanner for esphome."""
 
@@ -81,7 +89,8 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             adv.service_data,
             adv.manufacturer_data,
             None,
-            {"address_type": adv.address_type},
+            _ADDRESS_TYPE_CACHE.get(adv.address_type)
+            or {"address_type": adv.address_type},
             MONOTONIC_TIME(),
         )
 
@@ -105,6 +114,7 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                 int_to_bluetooth_address(adv.address),
                 adv.rssi,
                 adv.data,
-                {"address_type": adv.address_type},
+                _ADDRESS_TYPE_CACHE.get(adv.address_type)
+                or {"address_type": adv.address_type},
                 now,
             )


### PR DESCRIPTION
## Summary
- Cache the `{"address_type": adv.address_type}` dict at module level for common values (0 and 1) instead of allocating a new dict for every advertisement
- The dict is only consumed when a device is first seen (new BLEDevice creation), but was allocated unconditionally on every advertisement callback
- Also updates the `.pxd` Cython declaration

## Test plan
- [x] Existing tests pass
- [ ] Verify no regression in advertisement processing with ESPHome devices