### PR TITLE
fix: convert spurious CancelledError in connect to BleakError

### DIFF
--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -350,6 +350,14 @@ class ESPHomeClient(BaseBleakClient):
                 # rather than letting CancelledError leak to the caller.
                 current_task = asyncio.current_task()
                 if current_task is None or not current_task.cancelling():
+                    # Clean up the connection-state subscription that was
+                    # registered by bluetooth_device_connect above, since
+                    # we are bailing out before the normal disconnect path
+                    # runs.
+                    cancel_connection_state = self._cancel_connection_state
+                    self._cancel_connection_state = None
+                    if cancel_connection_state is not None:
+                        cancel_connection_state()
                     raise BleakError(
                         f"{self._description}: Connect attempt was cancelled"
                     ) from None

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -344,20 +344,24 @@ class ESPHomeClient(BaseBleakClient):
             try:
                 await connected_future
             except asyncio.CancelledError:
+                # Clean up the connection-state subscription that was
+                # registered by bluetooth_device_connect above, since we
+                # are bailing out before the normal disconnect path runs.
+                # Done for both the spurious-cancel (BleakError conversion)
+                # and the real-cancel (bare raise) branches so the
+                # subscription does not leak and trigger the
+                # ``not properly disconnected before destruction`` warning
+                # from ``__del__``.
+                cancel_connection_state = self._cancel_connection_state
+                self._cancel_connection_state = None
+                if cancel_connection_state is not None:
+                    cancel_connection_state()
                 # If the current task is not actually being cancelled,
                 # treat a cancellation of connected_future as a normal
                 # connection failure so bleak_retry_connector can retry
                 # rather than letting CancelledError leak to the caller.
                 current_task = asyncio.current_task()
                 if current_task is None or not current_task.cancelling():
-                    # Clean up the connection-state subscription that was
-                    # registered by bluetooth_device_connect above, since
-                    # we are bailing out before the normal disconnect path
-                    # runs.
-                    cancel_connection_state = self._cancel_connection_state
-                    self._cancel_connection_state = None
-                    if cancel_connection_state is not None:
-                        cancel_connection_state()
                     raise BleakError(
                         f"{self._description}: Connect attempt was cancelled"
                     ) from None

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -318,6 +318,16 @@ class ESPHomeClient(BaseBleakClient):
                         # to avoid a warning about an un-retrieved
                         # exception.
                         await connected_future
+                # If the current task is not actually being cancelled,
+                # the cancellation came from inside (e.g. the
+                # connect_future being cancelled externally). Convert
+                # it to a BleakError so bleak_retry_connector's retry
+                # logic can handle it instead of aborting the caller.
+                current_task = asyncio.current_task()
+                if current_task is None or not current_task.cancelling():
+                    raise BleakError(
+                        f"{self._description}: Connect attempt was cancelled"
+                    ) from None
                 raise
             except Exception as ex:
                 if connected_future.done():
@@ -331,7 +341,19 @@ class ESPHomeClient(BaseBleakClient):
                         await connected_future
                 connected_future.cancel(f"Unhandled exception in connect call: {ex}")
                 raise
-            await connected_future
+            try:
+                await connected_future
+            except asyncio.CancelledError:
+                # If the current task is not actually being cancelled,
+                # treat a cancellation of connected_future as a normal
+                # connection failure so bleak_retry_connector can retry
+                # rather than letting CancelledError leak to the caller.
+                current_task = asyncio.current_task()
+                if current_task is None or not current_task.cancelling():
+                    raise BleakError(
+                        f"{self._description}: Connect attempt was cancelled"
+                    ) from None
+                raise
 
         if pair:
             await self._pair()

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -649,10 +649,12 @@ async def test_bleak_client_connect_connected_future_cancelled_raises_bleak_erro
         captured.append(fut)
         return fut
 
+    mock_cancel_connection_state = Mock()
     with (
         patch.object(
             client._client,
             "bluetooth_device_connect",
+            return_value=mock_cancel_connection_state,
         ) as mock_connect,
         patch.object(client._loop, "create_future", capturing_create_future),
     ):
@@ -671,6 +673,10 @@ async def test_bleak_client_connect_connected_future_cancelled_raises_bleak_erro
         assert task.cancelling() == 0
 
     assert not client.is_connected
+    # The connection-state subscription must have been cleaned up before
+    # raising BleakError so it does not leak callbacks.
+    mock_cancel_connection_state.assert_called_once_with()
+    assert client._cancel_connection_state is None
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -710,6 +710,92 @@ async def test_bleak_client_connect_inner_cancelled_raises_bleak_error(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_real_task_cancel_propagates_inner(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test real task cancellation during ``bluetooth_device_connect``.
+
+    When the awaiting task is genuinely cancelled (``task.cancelling() > 0``)
+    while inside the ``bluetooth_device_connect`` call, the ``CancelledError``
+    must propagate so ``TaskGroup`` / ``asyncio.timeout`` semantics are
+    preserved.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    inside_connect = asyncio.Event()
+
+    async def _hang(*args: Any, **kwargs: Any) -> Any:
+        inside_connect.set()
+        await asyncio.Event().wait()
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=_hang,
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await inside_connect.wait()
+        # Genuine task cancel; cancelling() goes to 1 and CancelledError
+        # raises inside ``bluetooth_device_connect``. The bare ``raise`` in
+        # the except branch must propagate it as CancelledError.
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_real_task_cancel_propagates_outer(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test real task cancellation during the outer ``await connected_future``.
+
+    When the awaiting task is genuinely cancelled while parked on the
+    second ``await connected_future`` (after ``bluetooth_device_connect``
+    has returned), the ``CancelledError`` must propagate via the bare
+    ``raise`` so ``TaskGroup`` / ``asyncio.timeout`` semantics are preserved.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        return_value=Mock(),
+    ) as mock_connect:
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        # Wait for bluetooth_device_connect to return so we are parked on
+        # ``await connected_future``.
+        await asyncio.sleep(0)
+        mock_connect.assert_called_once()
+        # Genuine task cancel; cancelling() goes to 1 and CancelledError
+        # raises at ``await connected_future``. The bare ``raise`` in the
+        # except branch must propagate it as CancelledError.
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_raises_when_device_connect_raises(
     client_data: ESPHomeClientData,
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import pytest
 from aioesphomeapi import (
     APIClient,
+    APIConnectionError,
     APIVersion,
     BluetoothDevicePairing,
     BluetoothDeviceUnpairing,
@@ -618,6 +619,162 @@ async def test_bleak_client_connect(
         await client.disconnect()
 
     mock_disconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_connected_future_cancelled_raises_bleak_error(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test that external cancel of the connected_future raises BleakError.
+
+    Simulates a CancelledError leaking from the ESPHome connect path when the
+    connect_future is cancelled externally (not the awaiting task). It should
+    be converted to a BleakError so bleak_retry_connector can retry instead of
+    letting CancelledError propagate to the caller.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    original_create_future = client._loop.create_future
+    captured: list[asyncio.Future[bool]] = []
+
+    def capturing_create_future() -> asyncio.Future[bool]:
+        fut = original_create_future()
+        captured.append(fut)
+        return fut
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+        ) as mock_connect,
+        patch.object(client._loop, "create_future", capturing_create_future),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        # Wait for bluetooth_device_connect to return so we're parked on
+        # `await connected_future`.
+        await asyncio.sleep(0)
+        mock_connect.assert_called_once()
+        assert len(captured) == 1
+        # Cancel the connected_future directly; the awaiting task is not
+        # being cancelled.
+        captured[0].cancel()
+        with pytest.raises(BleakError, match="cancelled"):
+            await task
+        assert task.cancelling() == 0
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_inner_cancelled_raises_bleak_error(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test inner CancelledError converted to BleakError when task not cancelled.
+
+    If ``bluetooth_device_connect`` itself raises ``CancelledError`` (e.g. an
+    internal future was cancelled) while the awaiting task is not being
+    cancelled, ``connect`` should raise a ``BleakError`` instead.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=asyncio.CancelledError(),
+    ):
+        with pytest.raises(BleakError, match="cancelled"):
+            await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_raises_when_device_connect_raises(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test ``bluetooth_device_connect`` raising propagates and cancels future.
+
+    Exercises the ``except Exception`` branch around the
+    ``bluetooth_device_connect`` call when ``connected_future`` has not yet
+    been resolved. The exception must propagate unchanged and the unresolved
+    ``connected_future`` must be cancelled to avoid leaking it.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=APIConnectionError("boom"),
+    ):
+        with pytest.raises(BleakError, match="boom"):
+            await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_raises_after_connected_future_resolved(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    Test ``bluetooth_device_connect`` raising after the callback fires.
+
+    Exercises the ``if connected_future.done():`` branch inside the
+    ``except Exception`` handler around the ``bluetooth_device_connect``
+    call. The callback reports a failed connection (which sets a
+    ``BleakError`` on ``connected_future``), then ``bluetooth_device_connect``
+    itself raises. The already-resolved future must be drained (with the
+    BleakError suppressed) and the original exception must propagate.
+    """
+    ble_device = generate_ble_device(
+        "CC:BB:AA:DD:EE:FF", details={"source": ESP_MAC_ADDRESS, "address_type": 1}
+    )
+
+    bleak_client = BleakClient(ble_device, backend=_make_client_backend(client_data))
+    client: ESPHomeClient = bleak_client._backend
+    client._bluetooth_device.ble_connections_free = 10
+
+    async def _fire_callback_then_raise(
+        address: int,
+        on_bluetooth_connection_state: Any,
+        **kwargs: Any,
+    ) -> None:
+        # Resolve the future with a disconnect (sets BleakError exception),
+        # then raise to exercise the ``if connected_future.done():`` branch.
+        on_bluetooth_connection_state(False, 0, 0)
+        raise APIConnectionError("boom")
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=_fire_callback_then_raise,
+    ):
+        with pytest.raises(BleakError, match="boom"):
+            await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert not client.is_connected
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -773,10 +773,11 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
     client: ESPHomeClient = bleak_client._backend
     client._bluetooth_device.ble_connections_free = 10
 
+    mock_cancel_connection_state = Mock()
     with patch.object(
         client._client,
         "bluetooth_device_connect",
-        return_value=Mock(),
+        return_value=mock_cancel_connection_state,
     ) as mock_connect:
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
@@ -793,6 +794,10 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
         assert task.cancelled()
 
     assert not client.is_connected
+    # The connection-state subscription must be cleaned up on the
+    # real-cancel propagation path as well, so it does not leak.
+    mock_cancel_connection_state.assert_called_once_with()
+    assert client._cancel_connection_state is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When the local ``connected_future`` inside ``ESPHomeClient.connect`` is cancelled externally (for example, when the ``connect_future`` in ``aioesphomeapi`` is cancelled without the awaiting task itself being cancelled), the resulting ``CancelledError`` would leak out of ``connect`` and propagate up through ``bleak_retry_connector.establish_connection`` into caller code. Because ``CancelledError`` is a ``BaseException``, normal ``except Exception`` retry handlers do not catch it, causing integrations like ``airthings_ble`` to be marked as cancelled and abort setup instead of retrying.

This PR wraps both the ``bluetooth_device_connect`` call and the subsequent ``await connected_future`` in handlers that distinguish a genuine task cancellation from an internal future cancellation using ``asyncio.current_task().cancelling()``. When the current task is not actually being cancelled, the ``CancelledError`` is converted to a descriptive ``BleakError`` so ``bleak_retry_connector``'s retry logic can handle it as a normal connection failure. Real task cancellations still propagate unchanged.

Note: this is the mirror case of esphome/aioesphomeapi#1553 — both involve a ``task.cancelling()`` check but in opposite directions. #1553 describes a **swallow** bug (a real task cancellation is converted into ``APIConnectionCancelledError`` and the task's cancellation state is lost, breaking ``TaskGroup`` / ``asyncio.timeout()``). This PR and its companion esphome/aioesphomeapi#1572 fix an **upward leak** — a ``CancelledError`` escaping to the caller even though the awaiting task was never actually cancelled. Both are real bugs; #1553 still needs a separate fix in ``aioesphomeapi``.

Companion PR in aioesphomeapi: esphome/aioesphomeapi#1572.

## Tests

- ``test_bleak_client_connect_connected_future_cancelled_raises_bleak_error`` patches ``client._loop.create_future`` to capture the future, cancels it after ``bluetooth_device_connect`` returns, and asserts ``BleakClient.connect`` raises ``BleakError`` while ``task.cancelling() == 0``.
- ``test_bleak_client_connect_inner_cancelled_raises_bleak_error`` uses ``side_effect=asyncio.CancelledError()`` on ``bluetooth_device_connect`` to exercise the inner ``except asyncio.CancelledError`` branch and asserts it is converted to ``BleakError``.

Full ``tests/backend/test_client.py`` suite (30 tests) passes.