### PR TITLE
fix: convert spurious cancellation in APIConnectionManager.start to ESPHomeStartAborted

### DIFF
--- a/src/bleak_esphome/__init__.py
+++ b/src/bleak_esphome/__init__.py
@@ -1,9 +1,13 @@
 from .connect import connect_scanner
-from .connection_manager import APIConnectionManager, ESPHomeDeviceConfig, StartAborted
+from .connection_manager import (
+    APIConnectionManager,
+    ESPHomeDeviceConfig,
+    ESPHomeStartAborted,
+)
 
 __all__ = [
     "APIConnectionManager",
     "ESPHomeDeviceConfig",
-    "StartAborted",
+    "ESPHomeStartAborted",
     "connect_scanner",
 ]

--- a/src/bleak_esphome/__init__.py
+++ b/src/bleak_esphome/__init__.py
@@ -1,8 +1,9 @@
 from .connect import connect_scanner
-from .connection_manager import APIConnectionManager, ESPHomeDeviceConfig
+from .connection_manager import APIConnectionManager, ESPHomeDeviceConfig, StartAborted
 
 __all__ = [
     "APIConnectionManager",
     "ESPHomeDeviceConfig",
+    "StartAborted",
     "connect_scanner",
 ]

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -10,7 +10,7 @@ from aioesphomeapi import APIClient, ReconnectLogic
 import bleak_esphome
 
 
-class StartAborted(Exception):
+class ESPHomeStartAborted(Exception):
     """Raised when ``APIConnectionManager.start()`` is aborted by ``stop()``."""
 
 
@@ -68,12 +68,12 @@ class APIConnectionManager:
         except asyncio.CancelledError:
             # If the awaiting task is not actually being cancelled, the
             # CancelledError came from ``stop()`` cancelling the
-            # ``_start_future`` directly. Convert it to ``StartAborted``
+            # ``_start_future`` directly. Convert it to ``ESPHomeStartAborted``
             # so it does not leak as a spurious cancellation that breaks
             # ``TaskGroup`` / ``asyncio.timeout`` semantics for callers.
             current_task = asyncio.current_task()
             if current_task is None or not current_task.cancelling():
-                raise StartAborted("API connection start was aborted") from None
+                raise ESPHomeStartAborted("API connection start was aborted") from None
             raise
 
     async def stop(self) -> None:

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -10,6 +10,10 @@ from aioesphomeapi import APIClient, ReconnectLogic
 import bleak_esphome
 
 
+class StartAborted(Exception):
+    """Raised when ``APIConnectionManager.start()`` is aborted by ``stop()``."""
+
+
 class ESPHomeDeviceConfig(TypedDict):
     """Configuration for an ESPHome device."""
 
@@ -59,7 +63,18 @@ class APIConnectionManager:
     async def start(self) -> None:
         """Start the API connection."""
         await self._reconnect_logic.start()
-        await self._start_future
+        try:
+            await self._start_future
+        except asyncio.CancelledError:
+            # If the awaiting task is not actually being cancelled, the
+            # CancelledError came from ``stop()`` cancelling the
+            # ``_start_future`` directly. Convert it to ``StartAborted``
+            # so it does not leak as a spurious cancellation that breaks
+            # ``TaskGroup`` / ``asyncio.timeout`` semantics for callers.
+            current_task = asyncio.current_task()
+            if current_task is None or not current_task.cancelling():
+                raise StartAborted("API connection start was aborted") from None
+            raise
 
     async def stop(self) -> None:
         """Stop the API connection."""

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,0 +1,72 @@
+"""Tests for ``bleak_esphome.connection_manager``."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bleak_esphome.connection_manager import (
+    APIConnectionManager,
+    ESPHomeDeviceConfig,
+    StartAborted,
+)
+
+
+@pytest.mark.asyncio
+async def test_start_aborted_by_stop_raises_start_aborted() -> None:
+    """
+    ``start()`` raises ``StartAborted`` when ``stop()`` cancels its future.
+
+    The ``_start_future`` is a local future that ``stop()`` cancels to
+    abort a pending ``start()``. The resulting ``CancelledError`` must
+    be converted to ``StartAborted`` so it does not leak as a spurious
+    cancellation that breaks ``TaskGroup`` / ``asyncio.timeout``
+    semantics in callers (whose task is not actually being cancelled).
+    """
+    config: ESPHomeDeviceConfig = {"address": "test.local", "noise_psk": None}
+
+    with patch(
+        "bleak_esphome.connection_manager.ReconnectLogic"
+    ) as mock_reconnect_logic_cls:
+        mock_reconnect_logic = mock_reconnect_logic_cls.return_value
+        mock_reconnect_logic.start = AsyncMock()
+        mock_reconnect_logic.stop = AsyncMock()
+        manager = APIConnectionManager(config)
+        with patch.object(manager._cli, "disconnect", AsyncMock()):
+            start_task = asyncio.create_task(manager.start())
+            # Yield so start() reaches ``await self._start_future``.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            await manager.stop()
+            with pytest.raises(StartAborted):
+                await start_task
+            assert start_task.cancelling() == 0
+            assert not start_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_start_real_task_cancel_propagates_cancelled_error() -> None:
+    """
+    Genuine task cancellation of ``start()`` propagates ``CancelledError``.
+
+    When the awaiting task is genuinely cancelled (e.g. by a parent
+    ``TaskGroup`` or ``asyncio.timeout``), the ``CancelledError`` must
+    propagate so structured concurrency primitives can observe it.
+    """
+    config: ESPHomeDeviceConfig = {"address": "test.local", "noise_psk": None}
+
+    with patch(
+        "bleak_esphome.connection_manager.ReconnectLogic"
+    ) as mock_reconnect_logic_cls:
+        mock_reconnect_logic = mock_reconnect_logic_cls.return_value
+        mock_reconnect_logic.start = AsyncMock()
+        manager = APIConnectionManager(config)
+        start_task = asyncio.create_task(manager.start())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert start_task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+        assert start_task.cancelled()

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -10,18 +10,18 @@ import pytest
 from bleak_esphome.connection_manager import (
     APIConnectionManager,
     ESPHomeDeviceConfig,
-    StartAborted,
+    ESPHomeStartAborted,
 )
 
 
 @pytest.mark.asyncio
 async def test_start_aborted_by_stop_raises_start_aborted() -> None:
     """
-    ``start()`` raises ``StartAborted`` when ``stop()`` cancels its future.
+    ``start()`` raises ``ESPHomeStartAborted`` when ``stop()`` cancels its future.
 
     The ``_start_future`` is a local future that ``stop()`` cancels to
     abort a pending ``start()``. The resulting ``CancelledError`` must
-    be converted to ``StartAborted`` so it does not leak as a spurious
+    be converted to ``ESPHomeStartAborted`` so it does not leak as a spurious
     cancellation that breaks ``TaskGroup`` / ``asyncio.timeout``
     semantics in callers (whose task is not actually being cancelled).
     """
@@ -40,7 +40,7 @@ async def test_start_aborted_by_stop_raises_start_aborted() -> None:
             await asyncio.sleep(0)
             await asyncio.sleep(0)
             await manager.stop()
-            with pytest.raises(StartAborted):
+            with pytest.raises(ESPHomeStartAborted):
                 await start_task
             assert start_task.cancelling() == 0
             assert not start_task.cancelled()


### PR DESCRIPTION
## Summary

``APIConnectionManager.start()`` awaits a local ``_start_future`` which ``APIConnectionManager.stop()`` cancels to abort a pending start:

```python
async def start(self) -> None:
    await self._reconnect_logic.start()
    await self._start_future  # <-- raises CancelledError when stop() cancels it

async def stop(self) -> None:
    ...
    if not self._start_future.done():
        self._start_future.cancel()
```

The resulting ``CancelledError`` leaks out of ``start()`` to the caller even though the caller's task was never actually cancelled (``asyncio.current_task().cancelling() == 0``). Because ``CancelledError`` is a ``BaseException``, normal ``except Exception`` handlers do not catch it, and structured concurrency primitives like ``TaskGroup`` / ``asyncio.timeout()`` rely on ``cancelling()`` semantics that are violated by a spurious cancellation.

This is the same anti-pattern that was fixed in ``aioesphomeapi.APIClient.bluetooth_device_connect`` in esphome/aioesphomeapi#1572.

**Defensive fix, no current consumers**: a sweep of ``bleak_esphome`` itself, its docs and examples, and the Home Assistant ``esphome`` integration shows nothing currently catches ``CancelledError`` from ``APIConnectionManager.start()``, so this is not fixing an observable bug today. It is a correctness fix that prevents structured-concurrency misbehavior in *future* callers that wrap ``start()`` in a ``TaskGroup`` / ``asyncio.timeout()`` and call ``stop()`` concurrently.

## Fix

Wrap the ``await self._start_future`` in a ``try``/``except asyncio.CancelledError`` that:

- Re-raises the original ``CancelledError`` when ``current_task.cancelling() > 0`` (the caller really is being cancelled, e.g. by a parent ``TaskGroup`` or ``asyncio.timeout``).
- Otherwise raises a new ``ESPHomeStartAborted`` exception, which is exported from the ``bleak_esphome`` package and can be caught by callers via normal ``except ESPHomeStartAborted``.

The ``stop()`` method is unchanged. Future callers that want to detect "stop() was called concurrently with start()" should catch ``ESPHomeStartAborted`` rather than ``CancelledError``.

## Tests

- ``test_start_aborted_by_stop_raises_start_aborted`` — exercises the spurious-cancel branch by starting a manager, then calling ``stop()`` while ``start()`` is parked on ``_start_future``. Asserts ``start_task`` raises ``ESPHomeStartAborted`` and ``start_task.cancelled() is False``.
- ``test_start_real_task_cancel_propagates_cancelled_error`` — exercises the genuine-cancel branch by cancelling the ``start()`` task itself. Asserts ``CancelledError`` propagates and ``start_task.cancelled() is True``.