### PR TITLE
ci: scope release concurrency per ref to avoid contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## What

Scope the release job's concurrency group per ref instead of using a single global "release" lock.

## Why

The single global lock occasionally causes CI failures when two release jobs collide on different refs, which is the same problem we already fixed in dbus-fast.

## How

Replace `concurrency: release` with a group keyed on `github.head_ref || github.ref`, and set `cancel-in-progress: false` so concurrent refs serialize per branch rather than across the whole repo.

## Testing

Workflow change only, no runtime code touched; behavior will be verified the next time a release job runs.