### PR TITLE
ci: use astral setup-uv to provision Python and poetry for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,22 +81,19 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-          python-version: "3.14"
       - name: Install poetry
         run: uv tool install poetry
-      - name: Cache poetry virtualenv
-        uses: actions/cache@v4
+      - name: Setup Python 3.14
+        uses: actions/setup-python@v6
         with:
-          path: .venv
-          key: poetry-benchmark-${{ runner.os }}-3.14-${{ hashFiles('poetry.lock') }}
+          python-version: "3.14"
+          cache: "poetry"
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Install Dependencies
         run: |
           if [ "${{ matrix.extension }}" = "skip_cython" ]; then
@@ -75,11 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Python 3.14
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
+          enable-cache: true
           python-version: "3.14"
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           - "skip_cython"
           - "use_cython"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
@@ -56,6 +58,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: uv tool install poetry
+      - name: Cache poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         run: |
           if [ "${{ matrix.extension }}" = "skip_cython" ]; then
@@ -74,6 +81,8 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
@@ -83,6 +92,11 @@ jobs:
           python-version: "3.14"
       - name: Install poetry
         run: uv tool install poetry
+      - name: Cache poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-benchmark-${{ runner.os }}-3.14-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: "3.14"


### PR DESCRIPTION
## What

Swap the test and benchmark jobs from `actions/setup-python` plus `snok/install-poetry` over to `astral-sh/setup-uv`, which provisions both Python and poetry.

## Why

uv is faster and brings a shared download cache, so warm runs skip the Python install entirely; it also matches the pattern we already use in dbus-fast and aioesphomeapi, so the CI shape stays consistent across the sibling repos.

## How

Each test runner now sets up uv with `enable-cache: true` and the matrix's `python-version`, then installs poetry via `uv tool install poetry`; the rest of the job (poetry install, pytest, codspeed) is unchanged.

## Testing

Workflow change only, will be exercised by CI on this PR.