### PR TITLE
ci: fix release-job checkout for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.ref }}
+
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       # Do a dry run of PSR
       - name: Test release


### PR DESCRIPTION
## What

In the release job, check out `github.ref` instead of `github.head_ref`, then recreate the head-ref branch locally with `git switch -C`.

## Why

The release job on PR #335 failed with `A branch or tag with the name 'koan/fix-issue-329' could not be found`; the PR's head branch lives on a fork, so `actions/checkout` cannot resolve it against the upstream repo. `github.ref` (the merge ref on PRs) is always fetchable, and python-semantic-release still sees the original branch name once we recreate it locally.

Mirrors the dbus-fast fix in PRs #624 and #668.

## Testing

CI will exercise the release job on this PR.