### PR TITLE
ci: enable PLC0415 to require imports at top of file

### DIFF
--- a/examples/setup_scanner.py
+++ b/examples/setup_scanner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+import bleak
 import habluetooth
 
 from bleak_esphome import APIConnectionManager, ESPHomeDeviceConfig
@@ -24,8 +25,6 @@ ESPHOME_DEVICES: list[ESPHomeDeviceConfig] = [
 
 async def example_app() -> None:
     """Example application here."""
-    import bleak
-
     await asyncio.sleep(5)  # Give time for the scanner to find devices
 
     # Use bleak normally here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,16 +110,17 @@ ignore = [
     "D401", # First line of docstring should be in imperative mood
 ]
 select = [
-    "B",   # flake8-bugbear
-    "D",   # flake8-docstrings
-    "C4",  # flake8-comprehensions
-    "S",   # flake8-bandit
-    "F",   # pyflake
-    "E",   # pycodestyle
-    "W",   # pycodestyle
-    "UP",  # pyupgrade
-    "I",   # isort
-    "RUF", # ruff specific
+    "B",       # flake8-bugbear
+    "D",       # flake8-docstrings
+    "C4",      # flake8-comprehensions
+    "S",       # flake8-bandit
+    "F",       # pyflake
+    "E",       # pycodestyle
+    "W",       # pycodestyle
+    "UP",      # pyupgrade
+    "I",       # isort
+    "RUF",     # ruff specific
+    "PLC0415", # pylint: import should be at top-level of file
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -134,6 +135,7 @@ select = [
 "setup.py" = ["D100"]
 "conftest.py" = ["D100"]
 "docs/conf.py" = ["D100"]
+"build_ext.py" = ["PLC0415"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["bleak_esphome", "tests"]

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -12,6 +12,7 @@ from aioesphomeapi import (
     ESPHomeBluetoothGATTServices,
 )
 from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
@@ -46,8 +47,6 @@ async def test_client_usage_while_not_connected(
     with pytest.raises(
         BleakError, match=f"{ESP_NAME}.*{ESP_MAC_ADDRESS}.*not connected"
     ):
-        from bleak.backends.characteristic import BleakGATTCharacteristic
-
         char = BleakGATTCharacteristic(None, 1, "test", [], lambda: 20, None)
         await esphome_client.write_gatt_char(char, b"test", False)
 

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from aioesphomeapi import (
+    BLEConnectionError,
     BluetoothConnectionDroppedError,
     BluetoothDeviceClearCache,
     BluetoothProxyFeature,
@@ -149,8 +150,6 @@ async def test_on_bluetooth_connection_state_known_error_uses_name(
     client_data: ESPHomeClientData,
 ) -> None:
     """A known BLEConnectionError code uses its symbolic name in the message."""
-    from aioesphomeapi import BLEConnectionError
-
     client = _make_client(client_data)
     fut: asyncio.Future[bool] = client._loop.create_future()
     client._on_bluetooth_connection_state(


### PR DESCRIPTION
## What

Enable ruff rule PLC0415, which flags imports that are not at the top level of a file.

## Why

Function and block-scoped imports add startup-time surprises; keeping them at the top of the file is consistent with the rest of the codebase and makes dependency review easier.

## How

Added PLC0415 to the ruff select list; moved the three offending imports (one in `examples/setup_scanner.py`, one each in `tests/backend/test_client.py` and `tests/backend/test_client_branches.py`) up to the module imports. `build_ext.py` keeps a lazy Cython import for the optional build path, so it is added to the per-file-ignores.

## Testing

- `poetry run ruff check src/ tests/ examples/ build_ext.py` clean
- `poetry run pytest tests/backend/test_client.py tests/backend/test_client_branches.py` 61 passed
- `poetry run pre-commit run --all-files` on the touched files passes