### PR TITLE
feat(scanner): implement on-demand active scan window via proxy mode set

### DIFF
--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 
 from aioesphomeapi import (
+    APIClient,
+    APIConnectionError,
     BluetoothLEAdvertisement,
     BluetoothLERawAdvertisementsResponse,
     BluetoothScannerMode,
@@ -23,20 +27,34 @@ from habluetooth.base_scanner import BaseHaRemoteScanner
 if TYPE_CHECKING:
     from .device import ESPHomeBluetoothDevice
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class ESPHomeScanner(BaseHaRemoteScanner):
     """Scanner for esphome."""
 
-    __slots__ = ("_bluetooth_device",)
+    __slots__ = ("_active_window_lock", "_bluetooth_device", "_client")
 
     def __init__(self, *args: Any, **kwargs: Any):
         """Initialize the scanner."""
         super().__init__(*args, **kwargs)
         self._bluetooth_device: ESPHomeBluetoothDevice | None = None
+        self._client: APIClient | None = None
+        self._active_window_lock = asyncio.Lock()
 
     def set_bluetooth_device(self, device: ESPHomeBluetoothDevice) -> None:
         """Set the bluetooth device for this scanner."""
         self._bluetooth_device = device
+
+    def set_client(self, client: APIClient) -> None:
+        """
+        Bind the API client used to send scanner-mode requests.
+
+        Required for ``async_request_active_window`` to actually flip the
+        proxy; without it, requests are silently ignored. Only meaningful
+        for proxies that advertise the ``FEATURE_STATE_AND_MODE`` flag.
+        """
+        self._client = client
 
     def get_allocations(self) -> Allocations | None:
         """
@@ -83,6 +101,46 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             self.set_current_mode(mode)
         else:
             self.set_current_mode(None)
+
+    async def async_request_active_window(self, duration: float) -> bool:
+        """
+        Flip the proxy to ACTIVE for ``duration`` seconds, then restore.
+
+        Called by habluetooth's auto-mode scheduler. Restores the proxy
+        to whatever mode it last reported via ``async_update_scanner_state``;
+        if the prior mode is unknown the proxy is returned to PASSIVE.
+        Concurrent requests are serialized on a per-scanner lock so the
+        proxy only ever sees one mode transition at a time.
+        """
+        client = self._client
+        if client is None:
+            return False
+        async with self._active_window_lock:
+            prior = self.requested_mode
+            try:
+                await client.bluetooth_scanner_set_mode(BluetoothScannerMode.ACTIVE)
+            except APIConnectionError as ex:
+                _LOGGER.debug(
+                    "%s: failed to enter active scan window: %s", self.name, ex
+                )
+                return False
+            try:
+                await asyncio.sleep(duration)
+            finally:
+                restore = (
+                    BluetoothScannerMode.ACTIVE
+                    if prior is BluetoothScanningMode.ACTIVE
+                    else BluetoothScannerMode.PASSIVE
+                )
+                try:
+                    await client.bluetooth_scanner_set_mode(restore)
+                except APIConnectionError as ex:
+                    _LOGGER.debug(
+                        "%s: failed to restore scan mode after active window: %s",
+                        self.name,
+                        ex,
+                    )
+        return True
 
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:
         """Call the registered callback."""

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 from aioesphomeapi import (
@@ -114,6 +115,11 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         """
         client = self._client
         if client is None:
+            return False
+        # Defensive: guard the asyncio.sleep against non-finite / negative
+        # durations that an external caller might pass. Negative or NaN
+        # would otherwise propagate into a confusing scheduler error.
+        if not math.isfinite(duration) or duration < 0:
             return False
         async with self._active_window_lock:
             prior = self.requested_mode

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -110,8 +110,9 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         Called by habluetooth's auto-mode scheduler. Restores the proxy
         to whatever mode it last reported via ``async_update_scanner_state``;
         if the prior mode is unknown the proxy is returned to PASSIVE.
-        Concurrent requests are serialized on a per-scanner lock so the
-        proxy only ever sees one mode transition at a time.
+        Only one window may be open at a time; a request that arrives
+        while another window is in flight returns ``False`` immediately
+        so the caller can decide whether to retry.
         """
         client = self._client
         if client is None:
@@ -120,6 +121,8 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         # durations that an external caller might pass. Negative or NaN
         # would otherwise propagate into a confusing scheduler error.
         if not math.isfinite(duration) or duration < 0:
+            return False
+        if self._active_window_lock.locked():
             return False
         async with self._active_window_lock:
             prior = self.requested_mode
@@ -138,10 +141,13 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                     if prior is BluetoothScanningMode.ACTIVE
                     else BluetoothScannerMode.PASSIVE
                 )
+                # Shield the restore so an outer cancellation (e.g. shutdown)
+                # cannot abandon the proxy stuck in ACTIVE; the cancellation
+                # still propagates to the caller once the restore completes.
                 try:
-                    await client.bluetooth_scanner_set_mode(restore)
+                    await asyncio.shield(client.bluetooth_scanner_set_mode(restore))
                 except APIConnectionError as ex:
-                    _LOGGER.debug(
+                    _LOGGER.warning(
                         "%s: failed to restore scan mode after active window: %s",
                         self.name,
                         ex,

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -131,7 +131,7 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         async with self._active_window_lock:
             prior = self.requested_mode
             try:
-                await client.bluetooth_scanner_set_mode(BluetoothScannerMode.ACTIVE)
+                client.bluetooth_scanner_set_mode(BluetoothScannerMode.ACTIVE)
             except APIConnectionError as ex:
                 _LOGGER.debug(
                     "%s: failed to enter active scan window: %s", self.name, ex
@@ -145,15 +145,13 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                     if prior is BluetoothScanningMode.ACTIVE
                     else BluetoothScannerMode.PASSIVE
                 )
-                # Shield the restore from ordinary task cancellation so
-                # the proxy is not abandoned in ACTIVE; the cancellation
-                # still propagates to the caller once the restore
-                # completes. This does NOT cover full interpreter / event
-                # loop shutdown: once the loop is closing, the detached
-                # restore task will not get scheduled and the proxy may
-                # be left in ACTIVE until the connection drops.
+                # bluetooth_scanner_set_mode is a sync method that just
+                # queues the request on the API connection and returns
+                # None, so the only failure mode here is an immediate
+                # APIConnectionError if the connection has gone away.
+                # No shield is needed because nothing here yields.
                 try:
-                    await asyncio.shield(client.bluetooth_scanner_set_mode(restore))
+                    client.bluetooth_scanner_set_mode(restore)
                 except APIConnectionError as ex:
                     _LOGGER.warning(
                         "%s: failed to restore scan mode after active window: %s",

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -122,6 +122,10 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         # would otherwise propagate into a confusing scheduler error.
         if not math.isfinite(duration) or duration < 0:
             return False
+        # Safe: no await between the .locked() check and the acquire
+        # inside `async with`, so asyncio cannot schedule another
+        # coroutine in between and the check / acquire is effectively
+        # atomic on this lock.
         if self._active_window_lock.locked():
             return False
         async with self._active_window_lock:
@@ -141,9 +145,13 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                     if prior is BluetoothScanningMode.ACTIVE
                     else BluetoothScannerMode.PASSIVE
                 )
-                # Shield the restore so an outer cancellation (e.g. shutdown)
-                # cannot abandon the proxy stuck in ACTIVE; the cancellation
-                # still propagates to the caller once the restore completes.
+                # Shield the restore from ordinary task cancellation so
+                # the proxy is not abandoned in ACTIVE; the cancellation
+                # still propagates to the caller once the restore
+                # completes. This does NOT cover full interpreter / event
+                # loop shutdown: once the loop is closing, the detached
+                # restore task will not get scheduled and the proxy may
+                # be left in ACTIVE until the connection drops.
                 try:
                     await asyncio.shield(client.bluetooth_scanner_set_mode(restore))
                 except APIConnectionError as ex:

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -103,6 +103,7 @@ def connect_scanner(
             "%s [%s]: Bluetooth scanner state and mode support available", name, source
         )
         cli.subscribe_bluetooth_scanner_state(scanner.async_update_scanner_state)
+        scanner.set_client(cli)
 
     if feature_flags & BluetoothProxyFeature.RAW_ADVERTISEMENTS:
         cli.subscribe_bluetooth_le_raw_advertisements(

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -387,3 +388,44 @@ async def test_async_request_active_window_restore_failure_swallowed(
     scanner.set_client(mock_client)
     assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_rejects_overlap(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """A second request while a window is open returns False without flipping."""
+    gate = asyncio.Event()
+
+    async def fake_set_mode(mode: BluetoothScannerMode) -> None:
+        if mode is BluetoothScannerMode.ACTIVE:
+            await gate.wait()
+
+    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=fake_set_mode)
+    scanner.set_client(mock_client)
+    first = asyncio.create_task(scanner.async_request_active_window(0.0))
+    # Yield so the first task acquires the lock and blocks inside the entry call.
+    await asyncio.sleep(0)
+    assert await scanner.async_request_active_window(0.0) is False
+    # Only the first task has called bluetooth_scanner_set_mode (the entry flip).
+    assert mock_client.bluetooth_scanner_set_mode.await_count == 1
+    gate.set()
+    assert await first is True
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_runs_under_cancellation(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """Cancelling the task during the window still fires the restore call."""
+    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    scanner.set_client(mock_client)
+    task = asyncio.create_task(scanner.async_request_active_window(3600.0))
+    # Let the entry call complete and the task enter the sleep.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -358,6 +358,19 @@ async def test_async_request_active_window_set_failure_returns_false(
 
 
 @pytest.mark.asyncio
+async def test_async_request_active_window_rejects_invalid_duration(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """Negative or non-finite durations are rejected without touching the proxy."""
+    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    scanner.set_client(mock_client)
+    assert await scanner.async_request_active_window(-1.0) is False
+    assert await scanner.async_request_active_window(float("nan")) is False
+    assert await scanner.async_request_active_window(float("inf")) is False
+    mock_client.bluetooth_scanner_set_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_async_request_active_window_restore_failure_swallowed(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 from aioesphomeapi import (
     APIClient,
+    APIConnectionError,
     BluetoothLEAdvertisement,
     BluetoothLERawAdvertisement,
     BluetoothLERawAdvertisementsResponse,
@@ -294,3 +297,80 @@ async def test_scanner_get_allocations_matches_callback_format(
     assert pulled.allocated == expected
     assert pushed.allocated == expected
     assert all(isinstance(a, str) for a in pulled.allocated)
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_no_client(
+    scanner: ESPHomeScanner,
+) -> None:
+    """Without a bound API client the request is a no-op returning False."""
+    assert await scanner.async_request_active_window(1.0) is False
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_flips_then_restores_passive(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """A passive scanner is flipped to ACTIVE for the window then restored."""
+    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    scanner.set_client(mock_client)
+    # Start from PASSIVE
+    scanner.async_update_scanner_state(
+        BluetoothScannerStateResponse(
+            state=BluetoothScannerState.RUNNING,
+            mode=BluetoothScannerMode.PASSIVE,
+        )
+    )
+    assert await scanner.async_request_active_window(0.0) is True
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restores_active_when_proxy_active(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """A proxy already configured ACTIVE returns to ACTIVE after the window."""
+    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    scanner.set_client(mock_client)
+    scanner.async_update_scanner_state(
+        BluetoothScannerStateResponse(
+            state=BluetoothScannerState.RUNNING,
+            mode=BluetoothScannerMode.ACTIVE,
+        )
+    )
+    assert await scanner.async_request_active_window(0.0) is True
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.ACTIVE,)]
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_set_failure_returns_false(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """An APIConnectionError on the entry call yields False; no sleep, no restore."""
+    mock_client.bluetooth_scanner_set_mode = AsyncMock(
+        side_effect=APIConnectionError("boom")
+    )
+    scanner.set_client(mock_client)
+    assert await scanner.async_request_active_window(0.0) is False
+    assert mock_client.bluetooth_scanner_set_mode.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_active_window_restore_failure_swallowed(
+    scanner: ESPHomeScanner, mock_client: APIClient
+) -> None:
+    """If the restore call fails the window still reports success."""
+    call_count = 0
+
+    async def fake_set_mode(_mode: BluetoothScannerMode) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise APIConnectionError("restore failed")
+
+    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=fake_set_mode)
+    scanner.set_client(mock_client)
+    assert await scanner.async_request_active_window(0.0) is True
+    assert call_count == 2

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -418,12 +418,19 @@ async def test_async_request_active_window_restore_runs_under_cancellation(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """Cancelling the task during the window still fires the restore call."""
-    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    # Gate the entry call explicitly so the cancel happens after we
+    # know the worker has entered the asyncio.sleep, instead of
+    # relying on AsyncMock resolving in some specific number of loop
+    # iterations.
+    entered = asyncio.Event()
+
+    async def gated_set_mode(_mode: BluetoothScannerMode) -> None:
+        entered.set()
+
+    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=gated_set_mode)
     scanner.set_client(mock_client)
     task = asyncio.create_task(scanner.async_request_active_window(3600.0))
-    # Let the entry call complete and the task enter the sleep.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await entered.wait()
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 from aioesphomeapi import (
@@ -313,7 +313,7 @@ async def test_async_request_active_window_flips_then_restores_passive(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """A passive scanner is flipped to ACTIVE for the window then restored."""
-    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    mock_client.bluetooth_scanner_set_mode = MagicMock()
     scanner.set_client(mock_client)
     # Start from PASSIVE
     scanner.async_update_scanner_state(
@@ -323,7 +323,7 @@ async def test_async_request_active_window_flips_then_restores_passive(
         )
     )
     assert await scanner.async_request_active_window(0.0) is True
-    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.call_args_list]
     assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]
 
 
@@ -332,7 +332,7 @@ async def test_async_request_active_window_restores_active_when_proxy_active(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """A proxy already configured ACTIVE returns to ACTIVE after the window."""
-    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    mock_client.bluetooth_scanner_set_mode = MagicMock()
     scanner.set_client(mock_client)
     scanner.async_update_scanner_state(
         BluetoothScannerStateResponse(
@@ -341,7 +341,7 @@ async def test_async_request_active_window_restores_active_when_proxy_active(
         )
     )
     assert await scanner.async_request_active_window(0.0) is True
-    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.call_args_list]
     assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.ACTIVE,)]
 
 
@@ -350,12 +350,12 @@ async def test_async_request_active_window_set_failure_returns_false(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """An APIConnectionError on the entry call yields False; no sleep, no restore."""
-    mock_client.bluetooth_scanner_set_mode = AsyncMock(
+    mock_client.bluetooth_scanner_set_mode = MagicMock(
         side_effect=APIConnectionError("boom")
     )
     scanner.set_client(mock_client)
     assert await scanner.async_request_active_window(0.0) is False
-    assert mock_client.bluetooth_scanner_set_mode.await_count == 1
+    assert mock_client.bluetooth_scanner_set_mode.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -363,12 +363,12 @@ async def test_async_request_active_window_rejects_invalid_duration(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """Negative or non-finite durations are rejected without touching the proxy."""
-    mock_client.bluetooth_scanner_set_mode = AsyncMock()
+    mock_client.bluetooth_scanner_set_mode = MagicMock()
     scanner.set_client(mock_client)
     assert await scanner.async_request_active_window(-1.0) is False
     assert await scanner.async_request_active_window(float("nan")) is False
     assert await scanner.async_request_active_window(float("inf")) is False
-    mock_client.bluetooth_scanner_set_mode.assert_not_awaited()
+    mock_client.bluetooth_scanner_set_mode.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -378,13 +378,13 @@ async def test_async_request_active_window_restore_failure_swallowed(
     """If the restore call fails the window still reports success."""
     call_count = 0
 
-    async def fake_set_mode(_mode: BluetoothScannerMode) -> None:
+    def fake_set_mode(_mode: BluetoothScannerMode) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 2:
             raise APIConnectionError("restore failed")
 
-    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=fake_set_mode)
+    mock_client.bluetooth_scanner_set_mode = MagicMock(side_effect=fake_set_mode)
     scanner.set_client(mock_client)
     assert await scanner.async_request_active_window(0.0) is True
     assert call_count == 2
@@ -395,22 +395,22 @@ async def test_async_request_active_window_rejects_overlap(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """A second request while a window is open returns False without flipping."""
-    gate = asyncio.Event()
-
-    async def fake_set_mode(mode: BluetoothScannerMode) -> None:
-        if mode is BluetoothScannerMode.ACTIVE:
-            await gate.wait()
-
-    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=fake_set_mode)
+    mock_client.bluetooth_scanner_set_mode = MagicMock()
     scanner.set_client(mock_client)
-    first = asyncio.create_task(scanner.async_request_active_window(0.0))
-    # Yield so the first task acquires the lock and blocks inside the entry call.
-    await asyncio.sleep(0)
+    # Long duration so the first window is still inside asyncio.sleep
+    # when the second request arrives. The lock is held for the whole
+    # sleep, so the second call sees .locked() and fast-fails.
+    first = asyncio.create_task(scanner.async_request_active_window(3600.0))
+    # Wait until the first task has run the entry set_mode call;
+    # next line in the worker is the asyncio.sleep that holds the lock.
+    while mock_client.bluetooth_scanner_set_mode.call_count == 0:
+        await asyncio.sleep(0)
     assert await scanner.async_request_active_window(0.0) is False
     # Only the first task has called bluetooth_scanner_set_mode (the entry flip).
-    assert mock_client.bluetooth_scanner_set_mode.await_count == 1
-    gate.set()
-    assert await first is True
+    assert mock_client.bluetooth_scanner_set_mode.call_count == 1
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
 
 
 @pytest.mark.asyncio
@@ -418,21 +418,16 @@ async def test_async_request_active_window_restore_runs_under_cancellation(
     scanner: ESPHomeScanner, mock_client: APIClient
 ) -> None:
     """Cancelling the task during the window still fires the restore call."""
-    # Gate the entry call explicitly so the cancel happens after we
-    # know the worker has entered the asyncio.sleep, instead of
-    # relying on AsyncMock resolving in some specific number of loop
-    # iterations.
-    entered = asyncio.Event()
-
-    async def gated_set_mode(_mode: BluetoothScannerMode) -> None:
-        entered.set()
-
-    mock_client.bluetooth_scanner_set_mode = AsyncMock(side_effect=gated_set_mode)
+    mock_client.bluetooth_scanner_set_mode = MagicMock()
     scanner.set_client(mock_client)
     task = asyncio.create_task(scanner.async_request_active_window(3600.0))
-    await entered.wait()
+    # Wait until the entry call has fired (worker is now inside the
+    # asyncio.sleep) so the cancel hits the sleep rather than racing
+    # with the entry call's set_mode.
+    while mock_client.bluetooth_scanner_set_mode.call_count == 0:
+        await asyncio.sleep(0)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
-    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.await_args_list]
+    calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.call_args_list]
     assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]


### PR DESCRIPTION
Adds async_request_active_window on ESPHomeScanner so habluetooth can flip the proxy into ACTIVE mode for a bounded duration and then restore the prior mode. Pairs with habluetooth#448 which introduces the AUTO scanning mode. The APIClient is bound to the scanner only when FEATURE_STATE_AND_MODE is available, so older proxies keep their existing behavior. Tests cover the no client short circuit, passive and active restore, entry and restore failures, and invalid duration rejection.