### PR TITLE
ci: replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04-arm
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -202,7 +202,7 @@ jobs:
             musl: "musllinux"
           - os: macos-latest
             musl: "musllinux"
-          - os: macos-13
+          - os: macos-15-intel
             musl: "musllinux"
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
GitHub retired the macos-13 Intel runner, so the wheel build matrix fails to schedule that leg; switching to macos-15-intel restores Intel macOS wheel coverage, while macos-latest continues to provide arm64.