### PR TITLE
fix(build): parallelize cython build_ext and clean up redundant pass

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -5,6 +5,8 @@ import os
 from distutils.command.build_ext import build_ext
 from typing import Any
 
+_LOGGER = logging.getLogger(__name__)
+
 try:
     from setuptools import Extension
 except ImportError:
@@ -24,24 +26,22 @@ EXTENSIONS = [
 ]
 
 
-_LOGGER = logging.getLogger(__name__)
-
-
 class BuildExt(build_ext):
     """Build extension."""
 
     def build_extensions(self) -> None:
         """Build extensions."""
+        if getattr(self, "parallel", None) is None:
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
-        except Exception as ex:  # nosec
-            _LOGGER.debug("Failed to build extensions: %s", ex, exc_info=True)
-            pass
+        except Exception:  # nosec
+            _LOGGER.debug("Failed to build extensions", exc_info=True)
 
 
 def build(setup_kwargs: Any) -> None:
     """Build optional cython modules."""
-    if os.environ.get("SKIP_CYTHON", False):
+    if os.environ.get("SKIP_CYTHON"):
         return
     try:
         from Cython.Build import cythonize
@@ -61,4 +61,3 @@ def build(setup_kwargs: Any) -> None:
     except Exception:
         if os.environ.get("REQUIRE_CYTHON"):
             raise
-        pass


### PR DESCRIPTION
Ports the build_ext refinements from dbus-fast; the main win is enabling parallel compilation when distutils has not been told otherwise, which noticeably shortens the cython build on multi-core hosts. Also drops the unused exception binding, the redundant pass statements, and the harmless False default on the SKIP_CYTHON env check, so the file now mirrors the dbus-fast version aside from the docstrings and type hints this repo requires.