### PR TITLE
fix(scanner): narrow Optional before dict.get lookups

### DIFF
--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -148,8 +148,14 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         :meth:`async_set_scanning_mode` has been called, otherwise it
         falls back to ``state.mode``.
         """
-        self._configured_mode = _FIRMWARE_TO_HA_MODE.get(state.configured_mode)
-        mode = _FIRMWARE_TO_HA_MODE.get(state.mode)
+        configured_pb = state.configured_mode
+        self._configured_mode = (
+            _FIRMWARE_TO_HA_MODE.get(configured_pb)
+            if configured_pb is not None
+            else None
+        )
+        mode_pb = state.mode
+        mode = _FIRMWARE_TO_HA_MODE.get(mode_pb) if mode_pb is not None else None
         if self._intent is None:
             self.set_requested_mode(mode)
         if state.state == BluetoothScannerState.RUNNING:
@@ -198,7 +204,11 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             try:
                 await asyncio.sleep(duration)
             finally:
-                restore = _HA_TO_FIRMWARE_MODE.get(prior, BluetoothScannerMode.PASSIVE)
+                restore = (
+                    _HA_TO_FIRMWARE_MODE.get(prior, BluetoothScannerMode.PASSIVE)
+                    if prior is not None
+                    else BluetoothScannerMode.PASSIVE
+                )
                 # bluetooth_scanner_set_mode is a sync method that just
                 # queues the request on the API connection and returns
                 # None, so the only failure mode here is an immediate


### PR DESCRIPTION
## Summary

Follow-up to #356. Tightens three `dict.get(...)` call sites in `scanner.py` that pass an `Optional` key into a dict whose key type is the non-Optional enum.

- `_FIRMWARE_TO_HA_MODE.get(state.configured_mode)` — `state.configured_mode` is `BluetoothScannerMode | None`
- `_FIRMWARE_TO_HA_MODE.get(state.mode)` — `state.mode` is `BluetoothScannerMode | None`
- `_HA_TO_FIRMWARE_MODE.get(prior, ...)` — `prior` is `BluetoothScanningMode | None`

The project's pre-commit `mypy` hook installs no additional dependencies, so it can't see `aioesphomeapi` types and silently treats these as `Any` — that's why the gate passed at merge time. A strict mypy with deps installed flags `arg-type` errors at all three sites (a `None` key just returns the default at runtime, so this is type imprecision, not a runtime bug).

Narrows `None` first at each site so the lookups are both runtime-correct and type-correct under either configuration.

## Tests

Existing 32 scanner tests pass; no behavior change.