### PR TITLE
fix: recover advertisement subscriptions rejected by a stale proxy connection

### DIFF
--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -41,6 +41,11 @@ _LOGGER = logging.getLogger(__name__)
 # The last delay repeats.
 _SUBSCRIPTION_RETRY_DELAYS = (10.0, 30.0, 60.0)
 
+# Once past the expected reap window the fault is persistent; re-warn only
+# every Nth retry (~10 minutes at the steady 60s cadence) so it stays
+# visible at the default log level without flooding the log.
+_PERSISTENT_WARN_INTERVAL = 10
+
 # Firmware (BluetoothScannerMode) -> habluetooth (BluetoothScanningMode).
 _FIRMWARE_TO_HA_MODE: dict[BluetoothScannerMode, BluetoothScanningMode] = {
     BluetoothScannerMode.ACTIVE: BluetoothScanningMode.ACTIVE,
@@ -189,12 +194,13 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             if self._scanner_state_seen:
                 return
             # Warn while a stale subscriber is expected to still hold the slot
-            # (the device reaps it within ~150s); past that the fault is
-            # persistent and repeating the warning every retry forever would
-            # just be log spam, so de-escalate to debug.
+            # (the device reaps it within ~150s), then periodically so a
+            # persistent fault stays visible at the default log level without
+            # warning on every retry.
             log = (
                 _LOGGER.warning
                 if attempt < len(_SUBSCRIPTION_RETRY_DELAYS)
+                or attempt % _PERSISTENT_WARN_INTERVAL == 0
                 else _LOGGER.debug
             )
             log(
@@ -212,13 +218,17 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                 _LOGGER.debug("%s: failed to resubscribe: %s", self.name, ex)
                 return
             except Exception:
-                # The task is fire-and-forget, so without this an unexpected
-                # error would only surface as "Task exception was never
-                # retrieved" at GC time.
-                _LOGGER.exception(
-                    "%s: unexpected error resubscribing advertisements", self.name
+                # Keep retrying: the connection is still alive and nothing
+                # else re-arms the watchdog, so giving up here would leave
+                # the subscription silently unrecovered. Logging is throttled
+                # by the same warn/debug cadence as the retry message; the
+                # handler also keeps a fire-and-forget task's error from
+                # surfacing only as "Task exception was never retrieved".
+                log(
+                    "%s: unexpected error resubscribing advertisements",
+                    self.name,
+                    exc_info=True,
                 )
-                return
             attempt += 1
 
     def get_allocations(self) -> Allocations | None:
@@ -256,6 +266,13 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         :meth:`async_set_scanning_mode` has been called, otherwise it
         falls back to ``state.mode``.
         """
+        # Load-bearing invariant for the subscription watchdog: the firmware
+        # sends BluetoothScannerStateResponse only to the connection that
+        # holds the advertisement subscriber slot (the immediate reply to a
+        # successful subscribe, then state-change pushes); the client's
+        # subscribe_bluetooth_scanner_state only registers a local handler
+        # and sends nothing. Reaching this line therefore proves the
+        # advertisement subscription landed.
         self._scanner_state_seen = True
         configured_pb = state.configured_mode
         self._configured_mode = (

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -186,7 +186,16 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             await asyncio.sleep(delay)
             if self._scanner_state_seen:
                 return
-            _LOGGER.warning(
+            # Warn while a stale subscriber is expected to still hold the slot
+            # (the device reaps it within ~150s); past that the fault is
+            # persistent and repeating the warning every retry forever would
+            # just be log spam, so de-escalate to debug.
+            log = (
+                _LOGGER.warning
+                if attempt < len(_SUBSCRIPTION_RETRY_DELAYS)
+                else _LOGGER.debug
+            )
+            log(
                 "%s: No scanner state received %ss after subscribing; the device "
                 "likely still has a stale advertisement subscriber from a "
                 "previous connection; resubscribing",
@@ -199,6 +208,14 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                 # The connection is gone; the reconnect flow builds a new
                 # scanner with its own watchdog.
                 _LOGGER.debug("%s: failed to resubscribe: %s", self.name, ex)
+                return
+            except Exception:
+                # The task is fire-and-forget, so without this an unexpected
+                # error would only surface as "Task exception was never
+                # retrieved" at GC time.
+                _LOGGER.exception(
+                    "%s: unexpected error resubscribing advertisements", self.name
+                )
                 return
             attempt += 1
 

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -148,13 +148,15 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         """
         Bind the callable that re-sends the advertisement subscription.
 
-        Setting it arms the subscription watchdog started by
-        :meth:`async_setup`: if the proxy never reports scanner state, the
+        Must be called before :meth:`async_setup`; the watchdog is started
+        there, only if a callback is already bound, so binding one later
+        has no effect. If the proxy never reports scanner state, the
         subscription was silently rejected (the device's single subscriber
         slot was still held by a stale connection) and ``callback`` is
-        invoked to try again. Only meaningful for proxies that advertise
-        ``FEATURE_STATE_AND_MODE``; older firmware never reports scanner
-        state, so the watchdog would resubscribe forever.
+        invoked to try again; its return value (the unsubscribe callable
+        from aioesphomeapi) is ignored. Only meaningful for proxies that
+        advertise ``FEATURE_STATE_AND_MODE``; older firmware never reports
+        scanner state, so the watchdog would resubscribe forever.
         """
         self._resubscribe_advertisements = callback
 

--- a/src/bleak_esphome/backend/scanner.py
+++ b/src/bleak_esphome/backend/scanner.py
@@ -26,9 +26,20 @@ from habluetooth import Allocations, BluetoothScanningMode
 from habluetooth.base_scanner import BaseHaRemoteScanner
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .device import ESPHomeBluetoothDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+# The firmware answers a successful advertisement subscription with an
+# immediate BluetoothScannerStateResponse (both shipped in esphome 2025.5
+# with FEATURE_STATE_AND_MODE). If none arrives, the subscription was
+# silently rejected because a stale connection from a previous session
+# still holds the device's single subscriber slot; the device reaps such
+# connections via its keepalive after ~150s, so retry until one lands.
+# The last delay repeats.
+_SUBSCRIPTION_RETRY_DELAYS = (10.0, 30.0, 60.0)
 
 # Firmware (BluetoothScannerMode) -> habluetooth (BluetoothScanningMode).
 _FIRMWARE_TO_HA_MODE: dict[BluetoothScannerMode, BluetoothScanningMode] = {
@@ -55,6 +66,9 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         "_client",
         "_configured_mode",
         "_intent",
+        "_resubscribe_advertisements",
+        "_scanner_state_seen",
+        "_subscription_watchdog_task",
     )
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -65,6 +79,9 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         self._active_window_lock = asyncio.Lock()
         self._configured_mode: BluetoothScanningMode | None = None
         self._intent: BluetoothScanningMode | None = None
+        self._resubscribe_advertisements: Callable[[], object] | None = None
+        self._scanner_state_seen = False
+        self._subscription_watchdog_task: asyncio.Task[None] | None = None
 
     @property
     def configured_mode(self) -> BluetoothScanningMode | None:
@@ -127,6 +144,64 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         """
         self._client = client
 
+    def set_resubscribe_advertisements(self, callback: Callable[[], object]) -> None:
+        """
+        Bind the callable that re-sends the advertisement subscription.
+
+        Setting it arms the subscription watchdog started by
+        :meth:`async_setup`: if the proxy never reports scanner state, the
+        subscription was silently rejected (the device's single subscriber
+        slot was still held by a stale connection) and ``callback`` is
+        invoked to try again. Only meaningful for proxies that advertise
+        ``FEATURE_STATE_AND_MODE``; older firmware never reports scanner
+        state, so the watchdog would resubscribe forever.
+        """
+        self._resubscribe_advertisements = callback
+
+    def async_setup(self) -> Callable[[], None]:
+        """Set up the scanner and start the subscription watchdog if armed."""
+        unsetup = super().async_setup()
+        if self._resubscribe_advertisements is not None:
+            self._subscription_watchdog_task = asyncio.create_task(
+                self._subscription_watchdog()
+            )
+
+        def _unsetup() -> None:
+            if self._subscription_watchdog_task is not None:
+                self._subscription_watchdog_task.cancel()
+                self._subscription_watchdog_task = None
+            unsetup()
+
+        return _unsetup
+
+    async def _subscription_watchdog(self) -> None:
+        """Resubscribe advertisements until the proxy reports scanner state."""
+        if TYPE_CHECKING:
+            assert self._resubscribe_advertisements is not None
+        attempt = 0
+        while True:
+            delay = _SUBSCRIPTION_RETRY_DELAYS[
+                min(attempt, len(_SUBSCRIPTION_RETRY_DELAYS) - 1)
+            ]
+            await asyncio.sleep(delay)
+            if self._scanner_state_seen:
+                return
+            _LOGGER.warning(
+                "%s: No scanner state received %ss after subscribing; the device "
+                "likely still has a stale advertisement subscriber from a "
+                "previous connection; resubscribing",
+                self.name,
+                delay,
+            )
+            try:
+                self._resubscribe_advertisements()
+            except APIConnectionError as ex:
+                # The connection is gone; the reconnect flow builds a new
+                # scanner with its own watchdog.
+                _LOGGER.debug("%s: failed to resubscribe: %s", self.name, ex)
+                return
+            attempt += 1
+
     def get_allocations(self) -> Allocations | None:
         """
         Get current connection slot allocations for this ESPHome device.
@@ -162,6 +237,7 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         :meth:`async_set_scanning_mode` has been called, otherwise it
         falls back to ``state.mode``.
         """
+        self._scanner_state_seen = True
         configured_pb = state.configured_mode
         self._configured_mode = (
             _FIRMWARE_TO_HA_MODE.get(configured_pb)

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -106,9 +106,20 @@ def connect_scanner(
         scanner.set_client(cli)
 
     if feature_flags & BluetoothProxyFeature.RAW_ADVERTISEMENTS:
-        cli.subscribe_bluetooth_le_raw_advertisements(
-            scanner.async_on_raw_advertisements
+        subscribe = partial(
+            cli.subscribe_bluetooth_le_raw_advertisements,
+            scanner.async_on_raw_advertisements,
         )
+        subscribe()
+        if feature_flags & BluetoothProxyFeature.FEATURE_STATE_AND_MODE:
+            # The device only allows one advertisement subscriber at a time
+            # and silently rejects the request when a stale connection from a
+            # previous session still holds the slot; arming the scanner's
+            # subscription watchdog retries until the device reaps the stale
+            # connection and the subscription lands. Repeating the subscribe
+            # is safe: the callback is a bound method, so the connection's
+            # handler set dedupes it and only the request is re-sent.
+            scanner.set_resubscribe_advertisements(subscribe)
     else:
         cli.subscribe_bluetooth_le_advertisements(scanner.async_on_advertisement)
 

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -48,12 +48,18 @@ class APIConnectionManager:
 
     def _teardown_scanner(self) -> None:
         """Unset up and unregister the scanner if wired."""
-        if self._unsetup_scanner is not None:
-            self._unsetup_scanner()
-            self._unsetup_scanner = None
-        if self._unregister_scanner is not None:
-            self._unregister_scanner()
-            self._unregister_scanner = None
+        unsetup = self._unsetup_scanner
+        unregister = self._unregister_scanner
+        self._unsetup_scanner = None
+        self._unregister_scanner = None
+        try:
+            if unsetup is not None:
+                unsetup()
+        finally:
+            # The unregister must run even if unsetup raises; skipping it
+            # would leak the scanner registration in habluetooth's manager.
+            if unregister is not None:
+                unregister()
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Handle the disconnection of the API client."""

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -42,6 +42,7 @@ class APIConnectionManager:
         self._cli: APIClient | None = None
         self._reconnect_logic: ReconnectLogic | None = None
         self._unregister_scanner: Callable[[], None] | None = None
+        self._unsetup_scanner: Callable[[], None] | None = None
         self._disconnect_callbacks: set[Callable[[], None]] | None = None
         self._start_future: asyncio.Future[None] | None = None
 
@@ -53,6 +54,9 @@ class APIConnectionManager:
             for callback in list(self._disconnect_callbacks):
                 callback()
             self._disconnect_callbacks = None
+        if self._unsetup_scanner is not None:
+            self._unsetup_scanner()
+            self._unsetup_scanner = None
         if self._unregister_scanner is not None:
             self._unregister_scanner()
             self._unregister_scanner = None
@@ -66,7 +70,7 @@ class APIConnectionManager:
         client_data = bleak_esphome.connect_scanner(self._cli, device_info, True)
         scanner = client_data.scanner
         assert scanner is not None  # noqa: S101
-        scanner.async_setup()
+        self._unsetup_scanner = scanner.async_setup()
         self._unregister_scanner = habluetooth.get_manager().async_register_scanner(
             scanner
         )
@@ -135,6 +139,9 @@ class APIConnectionManager:
             await self._cli.disconnect()
         if self._start_future is not None and not self._start_future.done():
             self._start_future.cancel()
+        if self._unsetup_scanner is not None:
+            self._unsetup_scanner()
+            self._unsetup_scanner = None
         if self._unregister_scanner is not None:
             self._unregister_scanner()
             self._unregister_scanner = None

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -46,6 +46,15 @@ class APIConnectionManager:
         self._disconnect_callbacks: set[Callable[[], None]] | None = None
         self._start_future: asyncio.Future[None] | None = None
 
+    def _teardown_scanner(self) -> None:
+        """Unset up and unregister the scanner if wired."""
+        if self._unsetup_scanner is not None:
+            self._unsetup_scanner()
+            self._unsetup_scanner = None
+        if self._unregister_scanner is not None:
+            self._unregister_scanner()
+            self._unregister_scanner = None
+
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Handle the disconnection of the API client."""
         if self._disconnect_callbacks is not None:
@@ -54,12 +63,7 @@ class APIConnectionManager:
             for callback in list(self._disconnect_callbacks):
                 callback()
             self._disconnect_callbacks = None
-        if self._unsetup_scanner is not None:
-            self._unsetup_scanner()
-            self._unsetup_scanner = None
-        if self._unregister_scanner is not None:
-            self._unregister_scanner()
-            self._unregister_scanner = None
+        self._teardown_scanner()
 
     async def _on_connect(self) -> None:
         """Handle the connection of the API client."""
@@ -139,9 +143,4 @@ class APIConnectionManager:
             await self._cli.disconnect()
         if self._start_future is not None and not self._start_future.done():
             self._start_future.cancel()
-        if self._unsetup_scanner is not None:
-            self._unsetup_scanner()
-            self._unsetup_scanner = None
-        if self._unregister_scanner is not None:
-            self._unregister_scanner()
-            self._unregister_scanner = None
+        self._teardown_scanner()

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -21,6 +21,7 @@ from habluetooth import (
     get_manager,
 )
 
+from bleak_esphome.backend import scanner as scanner_module
 from bleak_esphome.backend.client import ESPHomeClientData
 from bleak_esphome.backend.device import ESPHomeBluetoothDevice
 from bleak_esphome.backend.scanner import ESPHomeScanner
@@ -565,3 +566,92 @@ async def test_active_window_restore_uses_intent(
     assert await scanner.async_request_active_window(0.0) is True
     calls = [c.args for c in mock_client.bluetooth_scanner_set_mode.call_args_list]
     assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_resubscribes_until_state_seen(
+    scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The watchdog re-sends the subscribe until scanner state arrives."""
+    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
+    resubscribe = MagicMock()
+    scanner.set_resubscribe_advertisements(resubscribe)
+    unsetup = scanner.async_setup()
+    task = scanner._subscription_watchdog_task
+    assert task is not None
+    while resubscribe.call_count < 2:
+        await asyncio.sleep(0)
+    scanner.async_update_scanner_state(
+        BluetoothScannerStateResponse(
+            state=BluetoothScannerState.RUNNING,
+            mode=BluetoothScannerMode.PASSIVE,
+        )
+    )
+    await asyncio.wait_for(task, timeout=1)
+    unsetup()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_no_retry_when_state_seen(
+    scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """State arriving before the first delay means no resubscribe at all."""
+    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
+    resubscribe = MagicMock()
+    scanner.set_resubscribe_advertisements(resubscribe)
+    unsetup = scanner.async_setup()
+    task = scanner._subscription_watchdog_task
+    assert task is not None
+    # Delivered before the watchdog task gets its first slice of the loop.
+    scanner.async_update_scanner_state(
+        BluetoothScannerStateResponse(
+            state=BluetoothScannerState.RUNNING,
+            mode=BluetoothScannerMode.PASSIVE,
+        )
+    )
+    await asyncio.wait_for(task, timeout=1)
+    resubscribe.assert_not_called()
+    unsetup()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_not_started_without_callback(
+    scanner: ESPHomeScanner,
+) -> None:
+    """No resubscribe callback (older firmware) means no watchdog task."""
+    unsetup = scanner.async_setup()
+    assert scanner._subscription_watchdog_task is None
+    unsetup()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_cancelled_on_unsetup(
+    scanner: ESPHomeScanner,
+) -> None:
+    """Unsetup cancels the watchdog while it is parked in its first delay."""
+    resubscribe = MagicMock()
+    scanner.set_resubscribe_advertisements(resubscribe)
+    unsetup = scanner.async_setup()
+    task = scanner._subscription_watchdog_task
+    assert task is not None
+    unsetup()
+    assert scanner._subscription_watchdog_task is None
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    resubscribe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_stops_on_api_error(
+    scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dead connection ends the watchdog; the reconnect flow takes over."""
+    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
+    resubscribe = MagicMock(side_effect=APIConnectionError("connection lost"))
+    scanner.set_resubscribe_advertisements(resubscribe)
+    unsetup = scanner.async_setup()
+    task = scanner._subscription_watchdog_task
+    assert task is not None
+    await asyncio.wait_for(task, timeout=1)
+    resubscribe.assert_called_once()
+    unsetup()

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -568,25 +569,36 @@ async def test_active_window_restore_uses_intent(
     assert calls == [(BluetoothScannerMode.ACTIVE,), (BluetoothScannerMode.PASSIVE,)]
 
 
+_RUNNING_PASSIVE_STATE = BluetoothScannerStateResponse(
+    state=BluetoothScannerState.RUNNING,
+    mode=BluetoothScannerMode.PASSIVE,
+)
+
+
+def _arm_watchdog(
+    scanner: ESPHomeScanner,
+    monkeypatch: pytest.MonkeyPatch,
+    resubscribe: MagicMock,
+) -> tuple[asyncio.Task[None], Callable[[], None]]:
+    """Arm the resubscribe watchdog with zero retry delay and set up."""
+    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
+    scanner.set_resubscribe_advertisements(resubscribe)
+    unsetup = scanner.async_setup()
+    task = scanner._subscription_watchdog_task
+    assert task is not None
+    return task, unsetup
+
+
 @pytest.mark.asyncio
 async def test_subscription_watchdog_resubscribes_until_state_seen(
     scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The watchdog re-sends the subscribe until scanner state arrives."""
-    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
     resubscribe = MagicMock()
-    scanner.set_resubscribe_advertisements(resubscribe)
-    unsetup = scanner.async_setup()
-    task = scanner._subscription_watchdog_task
-    assert task is not None
+    task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
     while resubscribe.call_count < 2:
         await asyncio.sleep(0)
-    scanner.async_update_scanner_state(
-        BluetoothScannerStateResponse(
-            state=BluetoothScannerState.RUNNING,
-            mode=BluetoothScannerMode.PASSIVE,
-        )
-    )
+    scanner.async_update_scanner_state(_RUNNING_PASSIVE_STATE)
     await asyncio.wait_for(task, timeout=1)
     unsetup()
 
@@ -596,19 +608,10 @@ async def test_subscription_watchdog_no_retry_when_state_seen(
     scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """State arriving before the first delay means no resubscribe at all."""
-    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
     resubscribe = MagicMock()
-    scanner.set_resubscribe_advertisements(resubscribe)
-    unsetup = scanner.async_setup()
-    task = scanner._subscription_watchdog_task
-    assert task is not None
+    task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
     # Delivered before the watchdog task gets its first slice of the loop.
-    scanner.async_update_scanner_state(
-        BluetoothScannerStateResponse(
-            state=BluetoothScannerState.RUNNING,
-            mode=BluetoothScannerMode.PASSIVE,
-        )
-    )
+    scanner.async_update_scanner_state(_RUNNING_PASSIVE_STATE)
     await asyncio.wait_for(task, timeout=1)
     resubscribe.assert_not_called()
     unsetup()
@@ -626,14 +629,11 @@ async def test_subscription_watchdog_not_started_without_callback(
 
 @pytest.mark.asyncio
 async def test_subscription_watchdog_cancelled_on_unsetup(
-    scanner: ESPHomeScanner,
+    scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Unsetup cancels the watchdog while it is parked in its first delay."""
+    """Unsetup cancels the watchdog before it ever runs."""
     resubscribe = MagicMock()
-    scanner.set_resubscribe_advertisements(resubscribe)
-    unsetup = scanner.async_setup()
-    task = scanner._subscription_watchdog_task
-    assert task is not None
+    task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
     unsetup()
     assert scanner._subscription_watchdog_task is None
     with pytest.raises(asyncio.CancelledError):
@@ -646,12 +646,8 @@ async def test_subscription_watchdog_stops_on_api_error(
     scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A dead connection ends the watchdog; the reconnect flow takes over."""
-    monkeypatch.setattr(scanner_module, "_SUBSCRIPTION_RETRY_DELAYS", (0.0,))
     resubscribe = MagicMock(side_effect=APIConnectionError("connection lost"))
-    scanner.set_resubscribe_advertisements(resubscribe)
-    unsetup = scanner.async_setup()
-    task = scanner._subscription_watchdog_task
-    assert task is not None
+    task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
     await asyncio.wait_for(task, timeout=1)
     resubscribe.assert_called_once()
     unsetup()

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import Callable
 from unittest.mock import MagicMock
 
@@ -651,3 +652,42 @@ async def test_subscription_watchdog_stops_on_api_error(
     await asyncio.wait_for(task, timeout=1)
     resubscribe.assert_called_once()
     unsetup()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_swallows_unexpected_error(
+    scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unexpected resubscribe error ends the watchdog without an orphan."""
+    resubscribe = MagicMock(side_effect=ValueError("boom"))
+    task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
+    await asyncio.wait_for(task, timeout=1)
+    assert task.exception() is None
+    resubscribe.assert_called_once()
+    unsetup()
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_deescalates_to_debug(
+    scanner: ESPHomeScanner,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retries past the escalation phase log at debug, not warning."""
+    resubscribe = MagicMock()
+    with caplog.at_level(logging.DEBUG, logger="bleak_esphome.backend.scanner"):
+        task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
+        while resubscribe.call_count < 4:
+            await asyncio.sleep(0)
+        scanner.async_update_scanner_state(_RUNNING_PASSIVE_STATE)
+        await asyncio.wait_for(task, timeout=1)
+    unsetup()
+    records = [
+        record
+        for record in caplog.records
+        if "No scanner state received" in record.message
+    ]
+    assert len(records) >= 4
+    # One retry delay is patched in, so only the first attempt warns.
+    assert [r for r in records if r.levelno == logging.WARNING] == records[:1]
+    assert all(r.levelno == logging.DEBUG for r in records[1:])

--- a/tests/backend/test_scanner.py
+++ b/tests/backend/test_scanner.py
@@ -658,12 +658,15 @@ async def test_subscription_watchdog_stops_on_api_error(
 async def test_subscription_watchdog_swallows_unexpected_error(
     scanner: ESPHomeScanner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An unexpected resubscribe error ends the watchdog without an orphan."""
+    """Unexpected resubscribe errors are logged and retried, not fatal."""
     resubscribe = MagicMock(side_effect=ValueError("boom"))
     task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
+    while resubscribe.call_count < 3:
+        await asyncio.sleep(0)
+    # Still retrying despite every attempt raising; state ends it cleanly.
+    scanner.async_update_scanner_state(_RUNNING_PASSIVE_STATE)
     await asyncio.wait_for(task, timeout=1)
     assert task.exception() is None
-    resubscribe.assert_called_once()
     unsetup()
 
 
@@ -691,3 +694,30 @@ async def test_subscription_watchdog_deescalates_to_debug(
     # One retry delay is patched in, so only the first attempt warns.
     assert [r for r in records if r.levelno == logging.WARNING] == records[:1]
     assert all(r.levelno == logging.DEBUG for r in records[1:])
+
+
+@pytest.mark.asyncio
+async def test_subscription_watchdog_rewarns_periodically(
+    scanner: ESPHomeScanner,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A persistent fault re-warns every Nth retry instead of going silent."""
+    resubscribe = MagicMock()
+    interval = scanner_module._PERSISTENT_WARN_INTERVAL
+    with caplog.at_level(logging.DEBUG, logger="bleak_esphome.backend.scanner"):
+        task, unsetup = _arm_watchdog(scanner, monkeypatch, resubscribe)
+        while resubscribe.call_count < interval + 1:
+            await asyncio.sleep(0)
+        scanner.async_update_scanner_state(_RUNNING_PASSIVE_STATE)
+        await asyncio.wait_for(task, timeout=1)
+    unsetup()
+    warnings = [
+        record
+        for record in caplog.records
+        if "No scanner state received" in record.message
+        and record.levelno == logging.WARNING
+    ]
+    # One retry delay is patched in, so attempt 0 warns (escalation phase)
+    # and attempt `interval` warns again (periodic re-warn).
+    assert len(warnings) == 2

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -77,3 +77,38 @@ async def test_can_connect_unavailable() -> None:
     device = ESPHomeBluetoothDevice("proxy", "AA:BB:CC:DD:EE:FF", available=False)
     device.ble_connections_free = 2
     assert _can_connect(device, "AA:BB:CC:DD:EE:FF") is False
+
+
+@pytest.mark.asyncio
+async def test_connect_arms_subscription_watchdog(
+    mock_client: APIClient, mock_device_info: DeviceInfo
+) -> None:
+    """RAW_ADVERTISEMENTS with FEATURE_STATE_AND_MODE arms the resubscribe."""
+    client_data = connect_scanner(mock_client, mock_device_info, available=True)
+    scanner = client_data.scanner
+    assert scanner is not None
+    assert scanner._resubscribe_advertisements is not None
+    mock_client.subscribe_bluetooth_le_raw_advertisements.assert_called_once()
+    # The armed callback re-issues the exact same subscribe call.
+    scanner._resubscribe_advertisements()
+    assert mock_client.subscribe_bluetooth_le_raw_advertisements.call_count == 2
+    first, second = mock_client.subscribe_bluetooth_le_raw_advertisements.call_args_list
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_connect_no_watchdog_without_state_and_mode(
+    mock_client: APIClient, mock_device_info: DeviceInfo
+) -> None:
+    """Without FEATURE_STATE_AND_MODE there is no signal, so no watchdog."""
+    info = dataclasses.replace(
+        mock_device_info,
+        bluetooth_proxy_feature_flags=(
+            BluetoothProxyFeature.PASSIVE_SCAN
+            | BluetoothProxyFeature.RAW_ADVERTISEMENTS
+        ),
+    )
+    client_data = connect_scanner(mock_client, info, available=True)
+    scanner = client_data.scanner
+    assert scanner is not None
+    assert scanner._resubscribe_advertisements is None

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -426,3 +426,22 @@ async def test_stop_unsets_up_scanner_if_set_up(
 
     unsetup.assert_called_once_with()
     assert cast(Callable[[], None] | None, manager._unsetup_scanner) is None
+
+
+@pytest.mark.asyncio
+async def test_teardown_scanner_unregisters_even_if_unsetup_raises(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """A raising unsetup must not skip the unregister or leave stale refs."""
+    unsetup = Mock(side_effect=RuntimeError("boom"))
+    unregister = Mock()
+    conn_manager._unsetup_scanner = unsetup
+    conn_manager._unregister_scanner = unregister
+
+    with pytest.raises(RuntimeError, match="boom"):
+        conn_manager._teardown_scanner()
+
+    unsetup.assert_called_once_with()
+    unregister.assert_called_once_with()
+    assert cast(Callable[[], None] | None, conn_manager._unsetup_scanner) is None
+    assert cast(Callable[[], None] | None, conn_manager._unregister_scanner) is None

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -397,3 +397,32 @@ async def test_start_twice_raises_runtime_error() -> None:
         await manager.stop()
         with pytest.raises(ESPHomeStartAborted):
             await start_task
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_unsets_up_scanner_when_set_up(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """``_on_disconnect`` calls the scanner unsetup callback and clears it."""
+    unsetup = Mock()
+    conn_manager._unsetup_scanner = unsetup
+
+    await conn_manager._on_disconnect(expected_disconnect=True)
+
+    unsetup.assert_called_once_with()
+    assert cast(Callable[[], None] | None, conn_manager._unsetup_scanner) is None
+
+
+@pytest.mark.asyncio
+async def test_stop_unsets_up_scanner_if_set_up(
+    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+) -> None:
+    """``stop`` calls the scanner unsetup callback and clears it."""
+    manager, _, _ = conn_manager_with_mocked_reconnect
+    unsetup = Mock()
+    manager._unsetup_scanner = unsetup
+
+    await manager.stop()
+
+    unsetup.assert_called_once_with()
+    assert cast(Callable[[], None] | None, manager._unsetup_scanner) is None

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -400,7 +400,7 @@ async def test_start_twice_raises_runtime_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_disconnect_unsets_up_scanner_when_set_up(
+async def test_on_disconnect_runs_scanner_unsetup(
     conn_manager: APIConnectionManager,
 ) -> None:
     """``_on_disconnect`` calls the scanner unsetup callback and clears it."""
@@ -414,7 +414,7 @@ async def test_on_disconnect_unsets_up_scanner_when_set_up(
 
 
 @pytest.mark.asyncio
-async def test_stop_unsets_up_scanner_if_set_up(
+async def test_stop_runs_scanner_unsetup(
     conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
 ) -> None:
     """``stop`` calls the scanner unsetup callback and clears it."""


### PR DESCRIPTION
The ESPHome bluetooth proxy only allows one advertisement subscriber at a time. When Home Assistant reconnects after an unclean drop, the previous connection can still hold the subscriber slot for up to ~150s until the device keepalive reaps it; the new subscribe is silently rejected, the API connection stays healthy, and no advertisements or scanner state ever arrive until the next full reconnect. Root cause analysis in home-assistant/core#175664.

Firmware that advertises FEATURE_STATE_AND_MODE always answers a successful subscription with an immediate BluetoothScannerStateResponse (both shipped together in esphome 2025.5), so a missing state response means the subscription was rejected. This arms a watchdog on the scanner that resubscribes with backoff (10s, 30s, then every 60s) until a state response arrives; once the device reaps the stale connection the retry lands and delivery recovers without tearing down the API connection. Repeating the subscribe is safe since the callback is a bound method and the connection's handler set dedupes it, so only the request is re-sent.

The connection manager now also runs the scanner unsetup callback on disconnect and stop; it was previously discarded, so the watchdog and the base scanner housekeeping are cancelled cleanly.

The firmware side is fixed in esphome/esphome#17423 by letting the newest subscriber take over the slot; this client side change covers devices running older firmware.
