### PR TITLE
feat: warn when a proxy never answers a connect request

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,6 +140,45 @@ the retry logic can move to another proxy. The fail fast disarms as soon
 as the proxy reports slot state again, or when a caller reusing the
 device marks it available on reconnect.
 
+## `The proxy has not answered the last N connect requests`
+
+Symptoms: every connect attempt to one device fails after the full connect
+timeout, and this library logs
+
+```
+The proxy has not answered the last 5 connect requests; it accepted each one
+but never reported the connection state, so this device cannot be reached
+through this proxy.
+```
+
+Meanwhile the proxy's own log shows the link being established normally:
+
+```
+[bluetooth_proxy] [0] [AA:BB:CC:DD:EE:FF] Connecting v3 without cache
+[esp32_ble_client] [0] [AA:BB:CC:DD:EE:FF] Connection open
+[esp32_ble_client] [0] [AA:BB:CC:DD:EE:FF] Service discovery complete
+```
+
+The GATT connection succeeded; what never arrives is the
+`BluetoothDeviceConnectionResponse` that tells the host about it. Because the
+host is still waiting, it tears the connection down when the timeout expires,
+and the cycle repeats.
+
+This does not recover on its own. The uncached connect
+(`CONNECT_V3_WITHOUT_CACHE`) is the only way to populate the service cache —
+the proxy discards its service list after sending it — so a connect that never
+completes can never produce a cache, and every later attempt takes the same
+uncached path. Restarting the proxy is a workaround; the fix is on the proxy.
+
+Upgrade the proxy firmware. One known instance is an ESPHome bug on the
+uncached connect path, where the connected reply was only sent once *both* the
+MTU and service-discovery events had arrived — so a peripheral that never
+completes the MTU exchange left the reply unsent. It affects ESPHome through
+2026.7.x and is fixed in 2026.8.0 (esphome/esphome#18198).
+
+If the warning persists on current firmware, capture the proxy log for one
+attempt and open an issue with both sides of the exchange.
+
 ## Can I pin a BLE device to a specific proxy?
 
 No. `bleak-esphome` does not decide which proxy connects to which device. It

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,7 +171,7 @@ completes can never produce a cache, and every later attempt takes the same
 uncached path. Restarting the proxy is a workaround; the fix is on the proxy.
 
 Upgrade the proxy firmware. One known instance is an ESPHome bug on the
-uncached connect path, where the connected reply was only sent once *both* the
+uncached connect path, where the connected reply was only sent once _both_ the
 MTU and service-discovery events had arrived — so a peripheral that never
 completes the MTU exchange left the reply unsent. It affects ESPHome through
 2026.7.x and is fixed in 2026.8.0 (esphome/esphome#18198).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,7 +179,7 @@ Upgrade the proxy firmware. One known instance is an ESPHome bug on the
 uncached connect path, where the connected reply was only sent once _both_ the
 MTU and service-discovery events had arrived — so a peripheral that never
 completes the MTU exchange left the reply unsent. It affects ESPHome through
-2026.7.x and is fixed in 2026.8.0 (esphome/esphome#18198).
+2026.7.x and is fixed in 2026.8.0 or later (esphome/esphome#18198).
 
 If the warning persists on current firmware, capture the proxy log for one
 attempt and open an issue with both sides of the exchange.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,18 +140,23 @@ the retry logic can move to another proxy. The fail fast disarms as soon
 as the proxy reports slot state again, or when a caller reusing the
 device marks it available on reconnect.
 
-## `The proxy has not answered the last N connect requests`
+## `No connection state reported for the last N connect requests`
 
 Symptoms: every connect attempt to one device fails after the full connect
 timeout, and this library logs
 
 ```
-The proxy has not answered the last 5 connect requests; it accepted each one
-but never reported the connection state, so this device cannot be reached
-through this proxy.
+No connection state reported for the last 5 connect requests, so this device
+cannot be reached through this proxy.
 ```
 
-Meanwhile the proxy's own log shows the link being established normally:
+Only the absence of a reply is observable from the host. The connect request
+is sent without an acknowledgement, so a proxy that never processed it and a
+proxy that processed it but never reported the result look identical here. A
+wedged proxy or a half-open API session produces this same symptom, so check
+that the proxy is responsive before assuming the cause below.
+
+One cause is a proxy whose own log shows the link being established normally:
 
 ```
 [bluetooth_proxy] [0] [AA:BB:CC:DD:EE:FF] Connecting v3 without cache

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -366,7 +366,7 @@ class ESPHomeClient(BaseBleakClient):
         # Reaching here means the proxy answered. aioesphomeapi unsubscribes
         # this callback before it sends the disconnect that follows a connect
         # timeout, so a timed-out attempt can never clear its own streak.
-        self._bluetooth_device.async_note_connect_response(self._ble_device.address)
+        self._bluetooth_device.async_note_connect_response(self._address_as_int)
         if not connected:
             self._async_ble_device_disconnected()
 
@@ -432,20 +432,23 @@ class ESPHomeClient(BaseBleakClient):
         connected_future.set_result(connected)
 
     def _async_note_connect_timeout(self) -> None:
-        """Warn when the proxy keeps ignoring connect requests for a device."""
+        """Warn when connect requests keep going unanswered for a device."""
         count = self._bluetooth_device.async_note_connect_timeout(
-            self._ble_device.address
+            self._address_as_int
         )
         if (
             count != CONNECT_TIMEOUT_WARN_THRESHOLD
             and count % CONNECT_TIMEOUT_WARN_INTERVAL
         ):
             return
+        # Only the absence of a reply is observable. The connect request is
+        # sent without an ack, so the host cannot tell an accepted request
+        # from one the proxy never processed, and naming a cause would point
+        # a wedged proxy or a half-open API session at the wrong fix.
         _LOGGER.warning(
-            "%s: The proxy has not answered the last %s connect requests; "
-            "it accepted each one but never reported the connection state, "
-            "so this device cannot be reached through this proxy. Upgrade the "
-            "ESPHome version on device %s and check its logs",
+            "%s: No connection state reported for the last %s connect "
+            "requests, so this device cannot be reached through this proxy. "
+            "Check device %s and its logs",
             self._description,
             count,
             self._device_info.name,

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -61,8 +61,9 @@ DEFAULT_TIMEOUT = 30.0
 # is restarted, and nothing else in this library reports that. Warn once the
 # streak is long enough to rule out ordinary retries, then repeat sparingly
 # so a condition that never self-heals stays visible without spamming.
+# Both count attempts, not seconds.
 CONNECT_TIMEOUT_WARN_THRESHOLD = 5
-CONNECT_TIMEOUT_WARN_INTERVAL = 60
+CONNECT_TIMEOUT_WARN_REPEAT_ATTEMPTS = 60
 
 # CCCD (Characteristic Client Config Descriptor)
 CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
@@ -436,7 +437,7 @@ class ESPHomeClient(BaseBleakClient):
         count = self._bluetooth_device.async_note_connect_timeout(self._address_as_int)
         if (
             count != CONNECT_TIMEOUT_WARN_THRESHOLD
-            and count % CONNECT_TIMEOUT_WARN_INTERVAL
+            and count % CONNECT_TIMEOUT_WARN_REPEAT_ATTEMPTS
         ):
             return
         # Only the absence of a reply is observable. The connect request is

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -433,9 +433,7 @@ class ESPHomeClient(BaseBleakClient):
 
     def _async_note_connect_timeout(self) -> None:
         """Warn when connect requests keep going unanswered for a device."""
-        count = self._bluetooth_device.async_note_connect_timeout(
-            self._address_as_int
-        )
+        count = self._bluetooth_device.async_note_connect_timeout(self._address_as_int)
         if (
             count != CONNECT_TIMEOUT_WARN_THRESHOLD
             and count % CONNECT_TIMEOUT_WARN_INTERVAL

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -56,6 +56,14 @@ GATT_READ_TIMEOUT = 30.0
 GATT_NOTIFY_TIMEOUT = 30.0
 DEFAULT_TIMEOUT = 30.0
 
+# A proxy that accepts a connect request but never reports the resulting
+# connection state leaves the device unreachable through it until the proxy
+# is restarted, and nothing else in this library reports that. Warn once the
+# streak is long enough to rule out ordinary retries, then repeat sparingly
+# so a condition that never self-heals stays visible without spamming.
+CONNECT_TIMEOUT_WARN_THRESHOLD = 5
+CONNECT_TIMEOUT_WARN_INTERVAL = 60
+
 # CCCD (Characteristic Client Config Descriptor)
 CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
 CCCD_NOTIFY_BYTES = b"\x01\x00"
@@ -355,6 +363,10 @@ class ESPHomeClient(BaseBleakClient):
             mtu,
             error,
         )
+        # Reaching here means the proxy answered. aioesphomeapi unsubscribes
+        # this callback before it sends the disconnect that follows a connect
+        # timeout, so a timed-out attempt can never clear its own streak.
+        self._bluetooth_device.async_note_connect_response(self._ble_device.address)
         if not connected:
             self._async_ble_device_disconnected()
 
@@ -419,6 +431,26 @@ class ESPHomeClient(BaseBleakClient):
         )
         connected_future.set_result(connected)
 
+    def _async_note_connect_timeout(self) -> None:
+        """Warn when the proxy keeps ignoring connect requests for a device."""
+        count = self._bluetooth_device.async_note_connect_timeout(
+            self._ble_device.address
+        )
+        if (
+            count != CONNECT_TIMEOUT_WARN_THRESHOLD
+            and count % CONNECT_TIMEOUT_WARN_INTERVAL
+        ):
+            return
+        _LOGGER.warning(
+            "%s: The proxy has not answered the last %s connect requests; "
+            "it accepted each one but never reported the connection state, "
+            "so this device cannot be reached through this proxy. Upgrade the "
+            "ESPHome version on device %s and check its logs",
+            self._description,
+            count,
+            self._device_info.name,
+        )
+
     @api_error_as_bleak_error
     async def connect(
         self, pair: bool, dangerous_use_bleak_cache: bool = False, **kwargs: Any
@@ -476,6 +508,11 @@ class ESPHomeClient(BaseBleakClient):
                     self._raise_if_spurious_cancellation()
                     raise
                 except Exception as ex:
+                    if isinstance(ex, TimeoutAPIError):
+                        # The only timeout raised from here is the one for a
+                        # connect response that never arrived; the free-slot
+                        # wait has already completed above.
+                        self._async_note_connect_timeout()
                     # The connect call's error is preferred over a stored
                     # future error as it is more descriptive.
                     self._normalize_connect_future(

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -130,8 +130,9 @@ class ESPHomeBluetoothDevice:
         next slot report; ``available`` is not restored by that, so a
         reusing caller must set it back to ``True`` on reconnect, which
         disarms the fail fast immediately. The free count stays zero
-        until the first slot report. This method never raises, so
-        teardown paths can call it without guards.
+        until the first slot report. Unanswered-connect streaks are
+        dropped with the rest of the dead session's state. This method
+        never raises, so teardown paths can call it without guards.
         """
         self.available = False
         # Distinct from ``available``: only an explicit unavailability

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -37,6 +37,28 @@ class ESPHomeBluetoothDevice:
     _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
     _seen_allocated: bool = False
     _warned_untrusted: bool = False
+    _unanswered_connects: dict[str, int] = field(default_factory=dict)
+
+    def async_note_connect_response(self, address: str) -> None:
+        """
+        Record that the proxy reported a connection state for ``address``.
+
+        Any response clears the streak, including a failure or a disconnect:
+        the proxy answering at all is what distinguishes a device that cannot
+        be reached from a proxy that has stopped replying.
+        """
+        self._unanswered_connects.pop(address, None)
+
+    def async_note_connect_timeout(self, address: str) -> int:
+        """
+        Record a connect request the proxy never answered for ``address``.
+
+        Returns the number of consecutive unanswered requests, so the caller
+        can decide when the streak is long enough to be worth reporting.
+        """
+        count = self._unanswered_connects.get(address, 0) + 1
+        self._unanswered_connects[address] = count
+        return count
 
     def async_subscribe_connection_slots(
         self, callback: Callable[[Allocations], None]

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -9,13 +9,23 @@ from typing import TYPE_CHECKING
 
 from bleak_retry_connector import Allocations
 from bluetooth_data_tools import int_to_bluetooth_address
+from lru import LRU  # pylint: disable=no-name-in-module
 
 from .cache import ESPHomeBluetoothCache
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, MutableMapping
 
 _LOGGER = logging.getLogger(__name__)
+
+# Bound on the unanswered-connect streaks kept per proxy. Only addresses whose
+# connect request went unanswered are tracked, and a reply drops the entry,
+# so the live set is small. The bound is for the ones that never come back:
+# a device seen once and gone, or a peripheral rotating its address, would
+# otherwise leave an entry for the life of the connection. Evicting the
+# least-recently-used only restarts a streak for an address that has been
+# quiet longer than 128 others, which cannot mask an ongoing failure.
+MAX_TRACKED_UNANSWERED_CONNECTS = 128
 
 
 @dataclass(slots=True)
@@ -37,7 +47,9 @@ class ESPHomeBluetoothDevice:
     _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
     _seen_allocated: bool = False
     _warned_untrusted: bool = False
-    _unanswered_connects: dict[str, int] = field(default_factory=dict)
+    _unanswered_connects: MutableMapping[str, int] = field(
+        default_factory=lambda: LRU(MAX_TRACKED_UNANSWERED_CONNECTS)
+    )
 
     def async_note_connect_response(self, address: str) -> None:
         """

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -137,6 +137,12 @@ class ESPHomeBluetoothDevice:
         # Distinct from ``available``: only an explicit unavailability
         # arms the wait entry guard.
         self._unavailable = True
+        # Streaks describe the session that just died. The restart this
+        # warning recommends would otherwise leave the leading-edge arm
+        # unreachable for those addresses, delaying the next warning to
+        # the repeat arm. A session that flaps often enough to keep
+        # resetting these is a failure the caller can already see.
+        self._unanswered_connects.clear()
         # Clear the dead session's allocated list and free count so a
         # reused device cannot serve stale state; ``limit`` keeps the
         # last reported capacity.

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -47,11 +47,11 @@ class ESPHomeBluetoothDevice:
     _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
     _seen_allocated: bool = False
     _warned_untrusted: bool = False
-    _unanswered_connects: MutableMapping[str, int] = field(
+    _unanswered_connects: MutableMapping[int, int] = field(
         default_factory=lambda: LRU(MAX_TRACKED_UNANSWERED_CONNECTS)
     )
 
-    def async_note_connect_response(self, address: str) -> None:
+    def async_note_connect_response(self, address: int) -> None:
         """
         Record that the proxy reported a connection state for ``address``.
 
@@ -61,7 +61,7 @@ class ESPHomeBluetoothDevice:
         """
         self._unanswered_connects.pop(address, None)
 
-    def async_note_connect_timeout(self, address: str) -> int:
+    def async_note_connect_timeout(self, address: int) -> int:
         """
         Record a connect request the proxy never answered for ``address``.
 

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -22,7 +22,7 @@ from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
     CONNECT_FREE_SLOT_TIMEOUT,
-    CONNECT_TIMEOUT_WARN_INTERVAL,
+    CONNECT_TIMEOUT_WARN_REPEAT_ATTEMPTS,
     CONNECT_TIMEOUT_WARN_THRESHOLD,
     GATT_HEADER_SIZE,
     ESPHomeClient,
@@ -2237,10 +2237,41 @@ async def test_connect_timeout_warns_again_on_the_sparse_interval(
         "bluetooth_device_connect",
         side_effect=TimeoutAPIError("Timeout waiting for connect response"),
     ):
-        for _ in range(CONNECT_TIMEOUT_WARN_INTERVAL):
+        for _ in range(CONNECT_TIMEOUT_WARN_REPEAT_ATTEMPTS):
             with pytest.raises(TimeoutError):
                 await bleak_client.connect(dangerous_use_bleak_cache=True)
 
     # The leading edge, then the interval multiple: two warnings, not one.
     assert caplog.text.count("No connection state reported") == 2
-    assert f"last {CONNECT_TIMEOUT_WARN_INTERVAL} connect requests" in caplog.text
+    expected = f"last {CONNECT_TIMEOUT_WARN_REPEAT_ATTEMPTS} connect requests"
+    assert expected in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_connect_error_response_clears_the_timeout_streak(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    An error response clears the streak, not only a successful one.
+
+    The proxy answering at all is what the streak measures, so the reset has
+    to sit above the error and disconnect returns. Without this only the
+    success path pins its placement.
+    """
+    bleak_client, client = bleak_pair
+    device = client._bluetooth_device
+    address = client._address_as_int
+    device.async_note_connect_timeout(address)
+    device.async_note_connect_timeout(address)
+
+    with patch.object(
+        client._client, "bluetooth_device_connect", return_value=Mock()
+    ) as mock_connect:
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        mock_connect.call_args_list[0][0][1](False, 0, 19)
+        with pytest.raises(BleakError):
+            await task
+
+    # Back to one: the streak was cleared by the error response.
+    assert device.async_note_connect_timeout(address) == 1

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -22,6 +22,7 @@ from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
     CONNECT_FREE_SLOT_TIMEOUT,
+    CONNECT_TIMEOUT_WARN_INTERVAL,
     CONNECT_TIMEOUT_WARN_THRESHOLD,
     GATT_HEADER_SIZE,
     ESPHomeClient,
@@ -2143,13 +2144,13 @@ async def test_connect_timeout_warns_once_streak_is_long_enough(
         for _ in range(CONNECT_TIMEOUT_WARN_THRESHOLD - 1):
             with pytest.raises(TimeoutError):
                 await bleak_client.connect(dangerous_use_bleak_cache=True)
-        assert "never reported the connection state" not in caplog.text
+        assert "No connection state reported" not in caplog.text
 
         with pytest.raises(TimeoutError):
             await bleak_client.connect(dangerous_use_bleak_cache=True)
 
     assert (
-        f"has not answered the last {CONNECT_TIMEOUT_WARN_THRESHOLD} connect requests"
+        f"last {CONNECT_TIMEOUT_WARN_THRESHOLD} connect requests"
         in caplog.text
     )
 
@@ -2171,7 +2172,7 @@ async def test_connect_timeout_warns_only_on_the_leading_edge(
             with pytest.raises(TimeoutError):
                 await bleak_client.connect(dangerous_use_bleak_cache=True)
 
-    assert caplog.text.count("never reported the connection state") == 1
+    assert caplog.text.count("No connection state reported") == 1
 
 
 @pytest.mark.asyncio
@@ -2218,4 +2219,31 @@ async def test_connect_response_clears_the_timeout_streak(
             with pytest.raises(TimeoutError):
                 await bleak_client.connect(dangerous_use_bleak_cache=True)
 
-    assert "never reported the connection state" not in caplog.text
+    assert "No connection state reported" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_warns_again_on_the_sparse_interval(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A condition that never recovers must stay visible.
+
+    The leading edge alone would scroll away, so the warning repeats on the
+    sparse interval. Without this the second arm of the cadence never runs.
+    """
+    bleak_client, client = bleak_pair
+    caplog.set_level(logging.WARNING)
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=TimeoutAPIError("Timeout waiting for connect response"),
+    ):
+        for _ in range(CONNECT_TIMEOUT_WARN_INTERVAL):
+            with pytest.raises(TimeoutError):
+                await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    # The leading edge, then the interval multiple: two warnings, not one.
+    assert caplog.text.count("No connection state reported") == 2
+    assert f"last {CONNECT_TIMEOUT_WARN_INTERVAL} connect requests" in caplog.text

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -2149,10 +2149,7 @@ async def test_connect_timeout_warns_once_streak_is_long_enough(
         with pytest.raises(TimeoutError):
             await bleak_client.connect(dangerous_use_bleak_cache=True)
 
-    assert (
-        f"last {CONNECT_TIMEOUT_WARN_THRESHOLD} connect requests"
-        in caplog.text
-    )
+    assert f"last {CONNECT_TIMEOUT_WARN_THRESHOLD} connect requests" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -14,6 +14,7 @@ from aioesphomeapi import (
     BluetoothProxyFeature,
     ESPHomeBluetoothGATTServices,
 )
+from aioesphomeapi.core import TimeoutAPIError
 from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
@@ -21,6 +22,7 @@ from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
     CONNECT_FREE_SLOT_TIMEOUT,
+    CONNECT_TIMEOUT_WARN_THRESHOLD,
     GATT_HEADER_SIZE,
     ESPHomeClient,
     ESPHomeClientData,
@@ -2117,3 +2119,103 @@ async def test_set_connection_params_not_connected(
     with pytest.raises(BleakError) as exc_info:
         await esphome_client.set_connection_params(800, 800, 0, 300)
     assert "is not connected" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_warns_once_streak_is_long_enough(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A proxy that never answers a connect request is reported.
+
+    The proxy accepts the request and then reports nothing, so the only
+    symptom is a repeating timeout. Nothing else in this library surfaces
+    that, which leaves the device silently unreachable.
+    """
+    bleak_client, client = bleak_pair
+    caplog.set_level(logging.WARNING)
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=TimeoutAPIError("Timeout waiting for connect response"),
+    ):
+        for _ in range(CONNECT_TIMEOUT_WARN_THRESHOLD - 1):
+            with pytest.raises(TimeoutError):
+                await bleak_client.connect(dangerous_use_bleak_cache=True)
+        assert "never reported the connection state" not in caplog.text
+
+        with pytest.raises(TimeoutError):
+            await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert (
+        f"has not answered the last {CONNECT_TIMEOUT_WARN_THRESHOLD} connect requests"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_warns_only_on_the_leading_edge(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Crossing the threshold warns once, not on every later attempt."""
+    bleak_client, client = bleak_pair
+    caplog.set_level(logging.WARNING)
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=TimeoutAPIError("Timeout waiting for connect response"),
+    ):
+        for _ in range(CONNECT_TIMEOUT_WARN_THRESHOLD + 3):
+            with pytest.raises(TimeoutError):
+                await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert caplog.text.count("never reported the connection state") == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_response_clears_the_timeout_streak(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A proxy that answers again starts the streak over, so no warning."""
+    bleak_client, client = bleak_pair
+    caplog.set_level(logging.WARNING)
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=TimeoutAPIError("Timeout waiting for connect response"),
+    ):
+        for _ in range(CONNECT_TIMEOUT_WARN_THRESHOLD - 1):
+            with pytest.raises(TimeoutError):
+                await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_gatt_get_services",
+            return_value=esphome_bluetooth_gatt_services,
+        ),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        mock_connect.call_args_list[0][0][1](True, 23, 0)
+        await task
+
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        side_effect=TimeoutAPIError("Timeout waiting for connect response"),
+    ):
+        for _ in range(CONNECT_TIMEOUT_WARN_THRESHOLD - 1):
+            with pytest.raises(TimeoutError):
+                await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert "never reported the connection state" not in caplog.text

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -14,7 +14,10 @@ from bleak_esphome.backend.device import (
     ESPHomeBluetoothDevice,
 )
 
-from ._helpers import BLE_ADDRESS, ESP_MAC_ADDRESS
+from ._helpers import ESP_MAC_ADDRESS
+
+# The streak map is keyed on the int address, as the sibling maps are.
+ADDRESS = 0xCCBBAADDEEFF
 
 
 @pytest.mark.asyncio
@@ -523,9 +526,9 @@ async def test_note_connect_timeout_counts_consecutive_attempts(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
     """Each unanswered connect request advances that address's streak."""
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 2
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 3
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 1
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 2
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 3
 
 
 @pytest.mark.asyncio
@@ -533,10 +536,10 @@ async def test_note_connect_response_clears_streak(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
     """A reported connection state resets the streak for that address."""
-    bluetooth_device.async_note_connect_timeout(BLE_ADDRESS)
-    bluetooth_device.async_note_connect_timeout(BLE_ADDRESS)
-    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    bluetooth_device.async_note_connect_timeout(ADDRESS)
+    bluetooth_device.async_note_connect_timeout(ADDRESS)
+    bluetooth_device.async_note_connect_response(ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 1
 
 
 @pytest.mark.asyncio
@@ -544,8 +547,8 @@ async def test_note_connect_response_without_streak_is_a_noop(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
     """Clearing an address that never timed out must not raise."""
-    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    bluetooth_device.async_note_connect_response(ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 1
 
 
 @pytest.mark.asyncio
@@ -553,13 +556,13 @@ async def test_connect_streaks_are_tracked_per_address(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
     """One unreachable device must not mask another on the same proxy."""
-    other = "11:22:33:44:55:66"
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    other = ADDRESS + 1
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 1
     assert bluetooth_device.async_note_connect_timeout(other) == 1
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 2
-    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 2
+    bluetooth_device.async_note_connect_response(ADDRESS)
     assert bluetooth_device.async_note_connect_timeout(other) == 2
-    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    assert bluetooth_device.async_note_connect_timeout(ADDRESS) == 1
 
 
 @pytest.mark.asyncio
@@ -575,7 +578,7 @@ async def test_connect_timeout_streaks_are_bounded(
     """
     overflow = 50
     for index in range(MAX_TRACKED_UNANSWERED_CONNECTS + overflow):
-        bluetooth_device.async_note_connect_timeout(f"AA:BB:CC:DD:{index:04X}")
+        bluetooth_device.async_note_connect_timeout(ADDRESS + 1 + index)
 
     assert len(bluetooth_device._unanswered_connects) == (
         MAX_TRACKED_UNANSWERED_CONNECTS
@@ -587,13 +590,15 @@ async def test_connect_timeout_streaks_evict_the_least_recently_used(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
     """Eviction must drop the stalest address, never the one still failing."""
-    still_failing = "AA:BB:CC:DD:EE:01"
+    still_failing = ADDRESS
     bluetooth_device.async_note_connect_timeout(still_failing)
 
     # Keep it the most recently used while pushing the rest past the bound.
     for index in range(MAX_TRACKED_UNANSWERED_CONNECTS * 2):
-        bluetooth_device.async_note_connect_timeout(f"AA:BB:CC:DD:{index:04X}")
+        bluetooth_device.async_note_connect_timeout(ADDRESS + 1 + index)
         bluetooth_device.async_note_connect_timeout(still_failing)
 
-    # Its streak survived, so a long run of other addresses cannot reset it.
-    assert bluetooth_device.async_note_connect_timeout(still_failing) > 2
+    # One initial note, one per loop iteration, then the call below: an exact
+    # count, so an eviction that silently reset it could not slip through.
+    expected = 1 + MAX_TRACKED_UNANSWERED_CONNECTS * 2 + 1
+    assert bluetooth_device.async_note_connect_timeout(still_failing) == expected

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -9,7 +9,10 @@ from unittest.mock import Mock
 import pytest
 from bleak_retry_connector import Allocations
 
-from bleak_esphome.backend.device import ESPHomeBluetoothDevice
+from bleak_esphome.backend.device import (
+    MAX_TRACKED_UNANSWERED_CONNECTS,
+    ESPHomeBluetoothDevice,
+)
 
 from ._helpers import BLE_ADDRESS, ESP_MAC_ADDRESS
 
@@ -557,3 +560,40 @@ async def test_connect_streaks_are_tracked_per_address(
     bluetooth_device.async_note_connect_response(BLE_ADDRESS)
     assert bluetooth_device.async_note_connect_timeout(other) == 2
     assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_streaks_are_bounded(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    The streak map must not grow without bound.
+
+    An address that times out once and is never seen again has nothing to
+    clear its entry, so a peripheral rotating its address would otherwise
+    leave one behind for the life of the proxy connection.
+    """
+    overflow = 50
+    for index in range(MAX_TRACKED_UNANSWERED_CONNECTS + overflow):
+        bluetooth_device.async_note_connect_timeout(f"AA:BB:CC:DD:{index:04X}")
+
+    assert len(bluetooth_device._unanswered_connects) == (
+        MAX_TRACKED_UNANSWERED_CONNECTS
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_streaks_evict_the_least_recently_used(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """Eviction must drop the stalest address, never the one still failing."""
+    still_failing = "AA:BB:CC:DD:EE:01"
+    bluetooth_device.async_note_connect_timeout(still_failing)
+
+    # Keep it the most recently used while pushing the rest past the bound.
+    for index in range(MAX_TRACKED_UNANSWERED_CONNECTS * 2):
+        bluetooth_device.async_note_connect_timeout(f"AA:BB:CC:DD:{index:04X}")
+        bluetooth_device.async_note_connect_timeout(still_failing)
+
+    # Its streak survived, so a long run of other addresses cannot reset it.
+    assert bluetooth_device.async_note_connect_timeout(still_failing) > 2

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -11,7 +11,7 @@ from bleak_retry_connector import Allocations
 
 from bleak_esphome.backend.device import ESPHomeBluetoothDevice
 
-from ._helpers import ESP_MAC_ADDRESS
+from ._helpers import BLE_ADDRESS, ESP_MAC_ADDRESS
 
 
 @pytest.mark.asyncio
@@ -513,3 +513,47 @@ async def test_subscribe_connection_slots_fires_on_change(
     assert third.free == 2
     assert third.slots == 2
     assert third.allocated == []
+
+
+@pytest.mark.asyncio
+async def test_note_connect_timeout_counts_consecutive_attempts(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """Each unanswered connect request advances that address's streak."""
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 2
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 3
+
+
+@pytest.mark.asyncio
+async def test_note_connect_response_clears_streak(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """A reported connection state resets the streak for that address."""
+    bluetooth_device.async_note_connect_timeout(BLE_ADDRESS)
+    bluetooth_device.async_note_connect_timeout(BLE_ADDRESS)
+    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+
+
+@pytest.mark.asyncio
+async def test_note_connect_response_without_streak_is_a_noop(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """Clearing an address that never timed out must not raise."""
+    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_streaks_are_tracked_per_address(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """One unreachable device must not mask another on the same proxy."""
+    other = "11:22:33:44:55:66"
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1
+    assert bluetooth_device.async_note_connect_timeout(other) == 1
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 2
+    bluetooth_device.async_note_connect_response(BLE_ADDRESS)
+    assert bluetooth_device.async_note_connect_timeout(other) == 2
+    assert bluetooth_device.async_note_connect_timeout(BLE_ADDRESS) == 1


### PR DESCRIPTION
A proxy can accept a connect request, open the GATT link and finish service discovery, yet never send the BluetoothDeviceConnectionResponse that reports the result. The host waits out the full connect timeout, tears the link down and retries, forever.

Nothing surfaced this. The timeout was logged at debug only, so the symptom reaching a consumer was an anonymous TimeoutError, while the proxy's own log showed a healthy connection. Diagnosing it meant correlating a host packet trace against the proxy log.

It also cannot self-heal: the uncached connect is the only way to populate the service cache, since the proxy discards its service list after sending it. A connect that never completes never produces a cache, so every later attempt takes the same uncached path.

Track consecutive unanswered connect requests per address on the shared ESPHomeBluetoothDevice, since a new client is constructed per attempt. Any reported connection state clears the streak, including an error or a disconnect: a proxy answering at all is a different condition, and aioesphomeapi unsubscribes the callback before the disconnect that follows a timeout, so an attempt cannot clear its own streak.

Warn on the leading edge once the streak rules out ordinary retries, then repeat sparingly so a condition that never recovers stays visible without spamming.