### PR TITLE
fix: release esp side connection when connect is cancelled after link up

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,6 +172,24 @@ they always match when the list is reported at all. Firmware that predates
 the allocated list reports used slots with an empty list; that mismatch
 skips reconciliation, so it cannot tear down a healthy client.
 
+## `Failed to release ESP-side connection` warnings
+
+When a connect attempt is abandoned after the proxy already reported the
+link up (a cancellation, an error after link up, a failed pairing or
+service discovery), the library sends a fire and forget disconnect so the
+proxy's connection slot is freed. If that send fails for a reason other
+than the API connection being gone, this warning names the device:
+
+```
+<name> [<source>]: <device>: Failed to release ESP-side connection, the proxy slot may stay allocated until it disconnects on its own: ...
+```
+
+The slot recovers when the proxy notices the dead link on its own or when
+its API connection drops, but until then it counts against the proxy's
+limit. A dead API connection is logged at DEBUG instead, because the
+firmware tears down every link it holds once its subscriber is gone —
+nothing leaks in that case.
+
 ## Connect attempts are rejected by `bleak` before the proxy is ever called
 
 The scanner is registered as non-connectable. This happens when the

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -218,6 +218,25 @@ class ESPHomeClient(BaseBleakClient):
             self._disconnected_callback()
             self._disconnected_callback = None
 
+    async def _shielded_disconnect(self) -> None:
+        """
+        Release the ESP-side connection, surviving re-cancellation.
+
+        The disconnect is shielded so a cancellation arriving while it is
+        running cannot interrupt it half-way and leave the device connected
+        on the ESP side. If a re-cancellation does arrive, the disconnect is
+        drained best-effort before the cancellation propagates. Errors are
+        suppressed: this is cleanup on an already-failing path and the
+        original outcome is the actionable one for the caller.
+        """
+        disconnect_task = asyncio.create_task(self._disconnect())
+        with contextlib.suppress(Exception):
+            try:
+                await asyncio.shield(disconnect_task)
+            except asyncio.CancelledError:
+                with contextlib.suppress(Exception):
+                    await disconnect_task
+
     def _on_bluetooth_connection_state(
         self,
         connected_future: asyncio.Future[bool],
@@ -233,16 +252,22 @@ class ESPHomeClient(BaseBleakClient):
             mtu,
             error,
         )
+        if not connected:
+            self._async_ble_device_disconnected()
+
+        if connected_future.done():
+            # The connect attempt already finished (timed out, failed, or
+            # was cancelled) so the owning ``connect()`` has bailed and
+            # cleanup may already have run. A late ``connected=True`` must
+            # not mark the client connected again: nobody owns it anymore
+            # and the state would never be corrected.
+            return
+
         if connected:
             self._is_connected = True
             if not self._mtu:
                 self._mtu = mtu
                 self._cache.set_gatt_mtu_cache(self._address_as_int, mtu)
-        else:
-            self._async_ble_device_disconnected()
-
-        if connected_future.done():
-            return
 
         if error:
             try:
@@ -328,6 +353,10 @@ class ESPHomeClient(BaseBleakClient):
                         # to avoid a warning about an un-retrieved
                         # exception.
                         await connected_future
+                else:
+                    # Make the abandoned attempt terminal so a late
+                    # connection-state callback cannot resurrect state.
+                    connected_future.cancel()
                 self._async_disconnected_cleanup()
                 # If the current task is not actually being cancelled,
                 # the cancellation came from inside (e.g. the
@@ -355,18 +384,18 @@ class ESPHomeClient(BaseBleakClient):
             try:
                 await connected_future
             except asyncio.CancelledError:
-                # Clean up the connection-state subscription that was
-                # registered by bluetooth_device_connect above, since we
-                # are bailing out before the normal disconnect path runs.
-                # Done for both the spurious-cancel (BleakError conversion)
-                # and the real-cancel (bare raise) branches so the
-                # subscription does not leak and trigger the
-                # ``not properly disconnected before destruction`` warning
-                # from ``__del__``.
-                cancel_connection_state = self._cancel_connection_state
-                self._cancel_connection_state = None
-                if cancel_connection_state is not None:
-                    cancel_connection_state()
+                # The cancellation may have been delivered after the link
+                # already came up (``connected_future`` can hold a result
+                # while the awaiting task was cancelled before resuming);
+                # release the ESP-side connection so the proxy's slot is
+                # not leaked on a connection no client owns.
+                if self._is_connected:
+                    await self._shielded_disconnect()
+                # Clean up local state and the connection-state
+                # subscription so it does not leak and trigger the
+                # ``not properly disconnected before destruction``
+                # warning from ``__del__``.
+                self._async_disconnected_cleanup()
                 # If the current task is not actually being cancelled,
                 # treat a cancellation of connected_future as a normal
                 # connection failure so bleak_retry_connector can retry
@@ -377,6 +406,11 @@ class ESPHomeClient(BaseBleakClient):
                     ) from None
                 raise
             except BaseException:
+                # The future can also fail after the link came up
+                # (``connected=True`` with an error code); release the
+                # ESP-side connection so the slot is not leaked.
+                if self._is_connected:
+                    await self._shielded_disconnect()
                 self._async_disconnected_cleanup()
                 raise
 
@@ -389,22 +423,9 @@ class ESPHomeClient(BaseBleakClient):
         except asyncio.CancelledError:
             # On cancel we must still raise CancelledError to avoid
             # blocking the cancellation even if the disconnect call
-            # fails. Shield the disconnect so a re-cancellation arriving
-            # while it is running cannot interrupt it half-way and leave
-            # the device connected on the ESP side. If a re-cancel does
-            # arrive, finish awaiting the disconnect before re-raising
-            # so the cancellation still propagates to the caller.
-            disconnect_task = asyncio.create_task(self._disconnect())
-            with contextlib.suppress(Exception):
-                try:
-                    await asyncio.shield(disconnect_task)
-                except asyncio.CancelledError:
-                    # Re-cancelled while the shielded disconnect was in
-                    # flight. Drain disconnect_task best-effort so it
-                    # does not leak before the original CancelledError
-                    # is re-raised below.
-                    with contextlib.suppress(Exception):
-                        await disconnect_task
+            # fails, so release the ESP-side connection best-effort
+            # before re-raising.
+            await self._shielded_disconnect()
             raise
         except Exception:
             # Best-effort cleanup: release the BLE connection on the ESP

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -252,10 +252,11 @@ class ESPHomeClient(BaseBleakClient):
 
     async def _release_orphaned_link(self) -> bool:
         """Release an orphaned link unless a newer connect owns it now."""
-        if self._is_connected:
+        if self._is_connected or self._cancel_connection_state is not None:
             # A newer connect on this client instance established a live
-            # link for the same address after the release was scheduled;
-            # releasing by address now would tear that link down.
+            # link for the same address, or has an attempt in flight
+            # (bleak_retry_connector retries on the same instance);
+            # releasing by address now would tear that attempt down.
             return False
         return await self._shielded_disconnect()
 
@@ -490,6 +491,19 @@ class ESPHomeClient(BaseBleakClient):
                     # link; it outranks the original error for the
                     # caller, which stays visible as the cause.
                     raise asyncio.CancelledError from connect_error
+                if isinstance(connect_error, Exception):
+                    # Same settle rationale as the setup-failure path:
+                    # let the slot free up before the retry's short entry
+                    # gate. Skipped for BaseException so a real signal is
+                    # not stalled behind a slow proxy.
+                    try:
+                        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+                    except Exception as settle_error:  # pylint: disable=broad-except
+                        _LOGGER.debug(
+                            "%s: Slot did not settle after failed connect: %s",
+                            self._description,
+                            settle_error,
+                        )
                 raise
 
         try:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -255,20 +255,29 @@ class ESPHomeClient(BaseBleakClient):
                 self._description,
                 exc,
             )
-        self._async_ble_device_disconnected()
+        # Local teardown without consumer notification: an abandoned
+        # attempt never handed the consumer a connected client, so it
+        # must not fire (and permanently null) ``disconnected_callback``,
+        # which has to survive for a later successful connect on this
+        # instance. Real disconnects go through
+        # ``_async_ble_device_disconnected`` instead.
+        self._async_disconnected_cleanup()
 
-    def _abandon_connect_attempt(self) -> None:
+    def _abandon_connect_attempt(self) -> bool:
         """
         Tear down an abandoned connect attempt.
 
         Releases the ESP-side link when it came up (the release tears
         down local state itself); otherwise only the local cleanup runs
-        so the connection-state subscription does not leak.
+        so the connection-state subscription does not leak. Returns True
+        when an ESP-side release was sent, so callers can skip the slot
+        settle for attempts that never held a slot.
         """
         if self._is_connected:
             self._release_connection_no_wait()
-        else:
-            self._async_disconnected_cleanup()
+            return True
+        self._async_disconnected_cleanup()
+        return False
 
     async def _settle_slot_after_failure(self, context: str) -> None:
         """
@@ -473,12 +482,13 @@ class ESPHomeClient(BaseBleakClient):
                 # let the slot settle before the retry connector tries
                 # again. A cancellation arriving during the settle
                 # propagates naturally and outranks the original error.
-                self._abandon_connect_attempt()
                 # Deliberately inside the ``connecting()`` pause: the
                 # settle concludes this attempt before the scanner is
-                # considered scanning again, and it short-circuits when
-                # a slot is already free.
-                await self._settle_slot_after_failure("failed connect")
+                # considered scanning again. It only runs when a release
+                # was actually sent; an attempt that never held a slot
+                # has nothing to settle and must not pause scanning.
+                if self._abandon_connect_attempt():
+                    await self._settle_slot_after_failure("failed connect")
                 raise
             except BaseException:
                 # A real signal must not be stalled behind a slow proxy,
@@ -503,8 +513,8 @@ class ESPHomeClient(BaseBleakClient):
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
             # connect error, then let the slot settle before the retry.
-            self._abandon_connect_attempt()
-            await self._settle_slot_after_failure("failed connect setup")
+            if self._abandon_connect_attempt():
+                await self._settle_slot_after_failure("failed connect setup")
             raise
         except BaseException:
             # A real signal must not be stalled behind a slow proxy,

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -227,7 +227,7 @@ class ESPHomeClient(BaseBleakClient):
                 "%s: Discarding stored connect error: %s", self._description, exc
             )
 
-    def _release_connection_no_wait(self) -> None:
+    def _release_connection_no_wait(self) -> bool:
         """
         Release the ESP-side connection without waiting for a response.
 
@@ -236,10 +236,14 @@ class ESPHomeClient(BaseBleakClient):
         frees the slot when it processes the request and reports the
         state change through the usual subscriptions. A failed send is a
         leaked proxy slot, so it is logged as a warning rather than
-        swallowed silently. Local state is torn down either way.
+        swallowed silently. Local state is torn down either way. Returns
+        True when the request was actually sent, so callers can skip
+        settling for a slot that cannot free.
         """
+        sent = False
         try:
             self._client.bluetooth_device_disconnect_no_wait(self._address_as_int)
+            sent = True
         except APIConnectionError as exc:
             # The proxy tears down every BLE link it holds once its API
             # subscriber is gone, so nothing is leaked here.
@@ -262,6 +266,7 @@ class ESPHomeClient(BaseBleakClient):
         # instance. Real disconnects go through
         # ``_async_ble_device_disconnected`` instead.
         self._async_disconnected_cleanup()
+        return sent
 
     def _abandon_connect_attempt(self) -> bool:
         """
@@ -274,8 +279,11 @@ class ESPHomeClient(BaseBleakClient):
         settle for attempts that never held a slot.
         """
         if self._is_connected:
-            self._release_connection_no_wait()
-            return True
+            # Settle only when the request went out; a failed send (a
+            # dead API connection above all) means ``free`` can never
+            # update over that same connection, so waiting would stall
+            # for the full timeout with scanning paused.
+            return self._release_connection_no_wait()
         self._async_disconnected_cleanup()
         return False
 
@@ -291,12 +299,22 @@ class ESPHomeClient(BaseBleakClient):
         """
         try:
             await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-        except Exception as settle_error:  # pylint: disable=broad-except
+        except TimeoutError as settle_error:
+            # The expected shape on a slow or saturated proxy.
             _LOGGER.debug(
                 "%s: Slot did not settle after %s: %s",
                 self._description,
                 context,
                 settle_error,
+            )
+        except Exception:  # pylint: disable=broad-except
+            # Anything else is a defect in the wait path, not a slow
+            # proxy; it must not hide at debug.
+            _LOGGER.warning(
+                "%s: Unexpected error while waiting for the slot to " "settle after %s",
+                self._description,
+                context,
+                exc_info=True,
             )
 
     def _on_bluetooth_connection_state(

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -321,8 +321,11 @@ class ESPHomeClient(BaseBleakClient):
             ):
                 # The ESP did just establish the link though (this is not
                 # a duplicate callback on a live connection, and no newer
-                # attempt is in flight on this instance); release it so
-                # the abandoned attempt does not pin a proxy slot.
+                # attempt on this instance has its connection-state
+                # subscription installed; during the brief RPC window
+                # before that, aioesphomeapi's own failure handlers
+                # release the link). Release it so the abandoned attempt
+                # does not pin a proxy slot.
                 _LOGGER.debug(
                     "%s: Releasing orphaned ESP-side connection",
                     self._description,
@@ -494,19 +497,19 @@ class ESPHomeClient(BaseBleakClient):
             # blocking the cancellation even if the disconnect call
             # fails, so release the ESP-side connection synchronously
             # before re-raising.
-            self._release_connection_no_wait()
+            self._abandon_connect_attempt()
             raise
         except Exception:
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
             # connect error, then let the slot settle before the retry.
-            self._release_connection_no_wait()
+            self._abandon_connect_attempt()
             await self._settle_slot_after_failure("failed connect setup")
             raise
         except BaseException:
             # A real signal must not be stalled behind a slow proxy,
             # so no settle here; the link is still released.
-            self._release_connection_no_wait()
+            self._abandon_connect_attempt()
             raise
 
     @api_error_as_bleak_error

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -160,6 +160,7 @@ class ESPHomeClient(BaseBleakClient):
         self._is_connected = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
+        self._orphan_disconnect_task: asyncio.Task[None] | None = None
         self._notify_cancels: dict[
             int, tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]
         ] = {}
@@ -261,6 +262,21 @@ class ESPHomeClient(BaseBleakClient):
             # cleanup may already have run. A late ``connected=True`` must
             # not mark the client connected again: nobody owns it anymore
             # and the state would never be corrected.
+            if connected and not self._is_connected:
+                # The ESP did just establish the link though; release it
+                # so the abandoned attempt does not pin a proxy slot. Not
+                # taken for a duplicate callback on a live connection,
+                # where ``_is_connected`` is still set.
+                _LOGGER.debug(
+                    "%s: Releasing orphaned ESP-side connection",
+                    self._description,
+                )
+                # Hold a reference so the task is not garbage collected
+                # before it runs; one connect attempt per client instance
+                # means at most one orphan release.
+                self._orphan_disconnect_task = self._loop.create_task(
+                    self._shielded_disconnect()
+                )
             return
 
         if connected:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -240,6 +240,14 @@ class ESPHomeClient(BaseBleakClient):
         """
         try:
             self._client.bluetooth_device_disconnect_no_wait(self._address_as_int)
+        except APIConnectionError as exc:
+            # The proxy tears down every BLE link it holds once its API
+            # subscriber is gone, so nothing is leaked here.
+            _LOGGER.debug(
+                "%s: API connection gone, ESP-side release skipped: %s",
+                self._description,
+                exc,
+            )
         except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.warning(
                 "%s: Failed to release ESP-side connection, the proxy slot "
@@ -411,7 +419,10 @@ class ESPHomeClient(BaseBleakClient):
                     # Make the abandoned attempt terminal so a late
                     # connection-state callback cannot resurrect state.
                     connected_future.cancel()
-                self._async_disconnected_cleanup()
+                # aioesphomeapi already told the ESP to drop the link in
+                # its own failure handlers, but abandoning uniformly does
+                # not rely on that; a duplicate release is harmless.
+                self._abandon_connect_attempt()
                 # If the current task is not actually being cancelled,
                 # the cancellation came from inside (e.g. the
                 # connect_future being cancelled externally). Convert
@@ -431,7 +442,7 @@ class ESPHomeClient(BaseBleakClient):
                     connected_future.cancel(
                         f"Unhandled exception in connect call: {ex}"
                     )
-                self._async_disconnected_cleanup()
+                self._abandon_connect_attempt()
                 raise
             try:
                 await connected_future
@@ -460,6 +471,10 @@ class ESPHomeClient(BaseBleakClient):
                 # again. A cancellation arriving during the settle
                 # propagates naturally and outranks the original error.
                 self._abandon_connect_attempt()
+                # Deliberately inside the ``connecting()`` pause: the
+                # settle concludes this attempt before the scanner is
+                # considered scanning again, and it short-circuits when
+                # a slot is already free.
                 await self._settle_slot_after_failure("failed connect")
                 raise
             except BaseException:
@@ -487,6 +502,11 @@ class ESPHomeClient(BaseBleakClient):
             # connect error, then let the slot settle before the retry.
             self._release_connection_no_wait()
             await self._settle_slot_after_failure("failed connect setup")
+            raise
+        except BaseException:
+            # A real signal must not be stalled behind a slow proxy,
+            # so no settle here; the link is still released.
+            self._release_connection_no_wait()
             raise
 
     @api_error_as_bleak_error

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -229,16 +229,24 @@ class ESPHomeClient(BaseBleakClient):
             )
 
     def _on_orphan_release_done(self, task: asyncio.Task[bool]) -> None:
-        """Drop a finished orphan release and surface one that never ran."""
+        """Drop a finished orphan release and surface one that blew up."""
         self._orphan_disconnect_tasks.discard(task)
+        # Nothing else observes this fire-and-forget task. A cancelled or
+        # failed release is reported by _shielded_disconnect itself; the
+        # wrapper can only end cancelled before its first step, or fail on
+        # something escaping that helper, and neither must go unretrieved.
         if task.cancelled():
-            # Nothing else observes this fire-and-forget task; a cancel
-            # here (loop teardown mid-flight) means the ESP link may
-            # still be up.
             _LOGGER.warning(
                 "%s: Orphaned ESP-side connection release was cancelled "
-                "before it completed, the proxy slot may stay allocated",
+                "before it started, the proxy slot may stay allocated",
                 self._description,
+            )
+        elif exc := task.exception():
+            _LOGGER.warning(
+                "%s: Orphaned ESP-side connection release failed, the proxy "
+                "slot may stay allocated: %s",
+                self._description,
+                exc,
             )
 
     async def _shielded_disconnect(self) -> bool:
@@ -251,23 +259,34 @@ class ESPHomeClient(BaseBleakClient):
         shielded, so a further cancel cannot reach the RPC either) and
         True is returned so the caller can honor the absorbed cancellation.
         The free-slot wait is skipped so cleanup cannot stall a
-        cancellation behind a slow proxy. A release that fails is a leaked
-        proxy slot, so it is logged as a warning rather than swallowed
-        silently.
+        cancellation behind a slow proxy. A release that fails or is
+        itself cancelled (loop teardown) is a leaked proxy slot, so it is
+        logged as a warning rather than swallowed silently.
         """
         disconnect_task = asyncio.create_task(self._disconnect_no_wait())
         absorbed = False
-        while True:
+        # Loop on the inner task's state, not on the awaits: once the
+        # inner task is done a shield returns it directly and awaiting a
+        # cancelled task raises without yielding, so a while True here
+        # would spin and starve the loop.
+        while not disconnect_task.done():
             try:
                 await asyncio.shield(disconnect_task)
-                break
             except asyncio.CancelledError:
-                # Keep draining under the shield: each further cancel is
-                # absorbed the same way, so the RPC always completes.
-                absorbed = True
+                # A cancel that reached the inner task itself is not a
+                # caller cancellation to honor; only count the ones the
+                # shield absorbed on our behalf.
+                absorbed = not disconnect_task.cancelled()
             except Exception:  # pylint: disable=broad-except
                 break
-        if not disconnect_task.cancelled() and (exc := disconnect_task.exception()):
+        if disconnect_task.cancelled():
+            _LOGGER.warning(
+                "%s: ESP-side connection release was cancelled before it "
+                "completed, the proxy slot may stay allocated until the "
+                "proxy disconnects on its own",
+                self._description,
+            )
+        elif exc := disconnect_task.exception():
             _LOGGER.warning(
                 "%s: Failed to release ESP-side connection, the proxy slot "
                 "may stay allocated until it disconnects on its own: %s",
@@ -488,9 +507,17 @@ class ESPHomeClient(BaseBleakClient):
             # Not a cancellation path, so let the slot settle before the
             # retry connector tries again; the retry's entry gate only
             # waits CONNECT_FREE_SLOT_TIMEOUT and would raise on a slow
-            # proxy otherwise. Errors here must not mask the setup error.
-            with contextlib.suppress(Exception):
+            # proxy otherwise. A settle failure must not mask the setup
+            # error, but it is the direct cause of that next gate failing,
+            # so it is logged rather than dropped.
+            try:
                 await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+            except Exception as settle_error:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "%s: Slot did not settle after failed connect setup: %s",
+                    self._description,
+                    settle_error,
+                )
             raise
 
     @api_error_as_bleak_error
@@ -505,7 +532,12 @@ class ESPHomeClient(BaseBleakClient):
     async def _disconnect_no_wait(self) -> None:
         """Release the ESP-side connection without the free-slot wait."""
         try:
-            await self._client.bluetooth_device_disconnect(self._address_as_int)
+            # Bound explicitly: the shielded cleanup paths absorb
+            # cancellation for the whole RPC, so aioesphomeapi's 20s
+            # default would make an uncancellable window that long.
+            await self._client.bluetooth_device_disconnect(
+                self._address_as_int, timeout=DISCONNECT_TIMEOUT
+            )
         finally:
             self._async_ble_device_disconnected()
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -249,6 +249,19 @@ class ESPHomeClient(BaseBleakClient):
             )
         self._async_ble_device_disconnected()
 
+    def _abandon_connect_attempt(self) -> None:
+        """
+        Tear down an abandoned connect attempt.
+
+        Releases the ESP-side link when it came up (the release tears
+        down local state itself); otherwise only the local cleanup runs
+        so the connection-state subscription does not leak.
+        """
+        if self._is_connected:
+            self._release_connection_no_wait()
+        else:
+            self._async_disconnected_cleanup()
+
     async def _settle_slot_after_failure(self, context: str) -> None:
         """
         Wait for the freed slot to settle after a failed attempt.
@@ -428,13 +441,8 @@ class ESPHomeClient(BaseBleakClient):
                 # already came up (``connected_future`` can hold a result
                 # while the awaiting task was cancelled before resuming);
                 # release the ESP-side connection so the proxy's slot is
-                # not leaked on a connection no client owns. The release
-                # tears down local state itself; otherwise clean up so
-                # the connection-state subscription does not leak.
-                if self._is_connected:
-                    self._release_connection_no_wait()
-                else:
-                    self._async_disconnected_cleanup()
+                # not leaked on a connection no client owns.
+                self._abandon_connect_attempt()
                 # If the current task is not actually being cancelled,
                 # treat a cancellation of connected_future as a normal
                 # connection failure so bleak_retry_connector can retry
@@ -451,19 +459,13 @@ class ESPHomeClient(BaseBleakClient):
                 # let the slot settle before the retry connector tries
                 # again. A cancellation arriving during the settle
                 # propagates naturally and outranks the original error.
-                if self._is_connected:
-                    self._release_connection_no_wait()
-                else:
-                    self._async_disconnected_cleanup()
+                self._abandon_connect_attempt()
                 await self._settle_slot_after_failure("failed connect")
                 raise
             except BaseException:
                 # A real signal must not be stalled behind a slow proxy,
                 # so no settle here.
-                if self._is_connected:
-                    self._release_connection_no_wait()
-                else:
-                    self._async_disconnected_cleanup()
+                self._abandon_connect_attempt()
                 raise
 
         try:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -296,7 +296,8 @@ class ESPHomeClient(BaseBleakClient):
 
         Capped to the same window as the next attempt's entry gate in
         ``connect()``; a settle failure is logged, never raised, so it
-        cannot mask the original error.
+        cannot mask the original error. Slot level, not link level: any
+        free slot on the proxy returns immediately.
         """
         try:
             await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
@@ -471,7 +472,11 @@ class ESPHomeClient(BaseBleakClient):
                     raise
                 except BaseException:
                     # True BaseExceptions bypass the outer settle; still
-                    # release the link.
+                    # release the link and normalize the future.
+                    if connected_future.done():
+                        self._retrieve_future_error(connected_future)
+                    else:
+                        connected_future.cancel()
                     self._abandon_connect_attempt()
                     raise
                 try:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -302,14 +302,16 @@ class ESPHomeClient(BaseBleakClient):
         """
         Wait for the freed slot to settle after a failed attempt.
 
-        The retry connector's entry gate only waits
+        The next attempt's entry gate in ``connect()`` only waits
         ``CONNECT_FREE_SLOT_TIMEOUT`` and would raise on a slow proxy
-        otherwise. A settle failure must not mask the original error,
-        but it is the direct cause of that next gate failing, so it is
-        logged rather than dropped.
+        otherwise, so the settle is capped to that same window; waiting
+        longer cannot help a gate that has already given up and only
+        delays surfacing the original error. A settle failure must not
+        mask that error, but it is the direct cause of the next gate
+        failing, so it is logged rather than dropped.
         """
         try:
-            await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+            await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
         except TimeoutError as settle_error:
             # The expected shape on a slow or saturated proxy.
             _LOGGER.debug(
@@ -352,23 +354,33 @@ class ESPHomeClient(BaseBleakClient):
             # cleanup may already have run. A late ``connected=True`` must
             # not mark the client connected again: nobody owns it anymore
             # and the state would never be corrected.
-            if (
-                connected
-                and not self._is_connected
-                and self._cancel_connection_state is None
-            ):
-                # The ESP did just establish the link though (this is not
-                # a duplicate callback on a live connection, and no newer
-                # attempt on this instance has its connection-state
-                # subscription installed; during the brief RPC window
-                # before that, aioesphomeapi's own failure handlers
-                # release the link). Release it so the abandoned attempt
-                # does not pin a proxy slot.
-                _LOGGER.debug(
-                    "%s: Releasing orphaned ESP-side connection",
-                    self._description,
-                )
-                self._release_connection_no_wait()
+            if connected and not self._is_connected:
+                if self._cancel_connection_state is None:
+                    # The ESP did just establish the link though (this is
+                    # not a duplicate callback on a live connection, and
+                    # no newer attempt on this instance has its
+                    # connection-state subscription installed; during the
+                    # brief RPC window before that, aioesphomeapi's own
+                    # failure handlers release the link). Release it so
+                    # the abandoned attempt does not pin a proxy slot.
+                    _LOGGER.debug(
+                        "%s: Releasing orphaned ESP-side connection",
+                        self._description,
+                    )
+                    self._release_connection_no_wait()
+                else:
+                    # The subscription that delivered this callback is
+                    # still installed, so the owning ``connect()`` has not
+                    # unwound yet and its abandonment runs next. Mark the
+                    # link up so that abandonment releases it; skipping
+                    # silently here would leak the slot, since the
+                    # abandonment only releases when the link came up.
+                    _LOGGER.debug(
+                        "%s: Link came up on an abandoned attempt; "
+                        "deferring the release to its abandonment",
+                        self._description,
+                    )
+                    self._is_connected = True
             return
 
         if connected:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 DEFAULT_MTU = 23
 GATT_HEADER_SIZE = 3
 DISCONNECT_TIMEOUT = 5.0
+SHIELDED_DISCONNECT_TIMEOUT = 5.0
 CONNECT_FREE_SLOT_TIMEOUT = 2.0
 GATT_READ_TIMEOUT = 30.0
 DEFAULT_TIMEOUT = 30.0
@@ -249,6 +250,15 @@ class ESPHomeClient(BaseBleakClient):
                 exc,
             )
 
+    async def _release_orphaned_link(self) -> bool:
+        """Release an orphaned link unless a newer connect owns it now."""
+        if self._is_connected:
+            # A newer connect on this client instance established a live
+            # link for the same address after the release was scheduled;
+            # releasing by address now would tear that link down.
+            return False
+        return await self._shielded_disconnect()
+
     async def _shielded_disconnect(self) -> bool:
         """
         Release the ESP-side connection, surviving re-cancellation.
@@ -263,7 +273,9 @@ class ESPHomeClient(BaseBleakClient):
         itself cancelled (loop teardown) is a leaked proxy slot, so it is
         logged as a warning rather than swallowed silently.
         """
-        disconnect_task = asyncio.create_task(self._disconnect_no_wait())
+        disconnect_task = asyncio.create_task(
+            self._disconnect_no_wait(SHIELDED_DISCONNECT_TIMEOUT)
+        )
         absorbed = False
         # Loop on the inner task's state, not on the awaits: once the
         # inner task is done a shield returns it directly and awaiting a
@@ -276,7 +288,7 @@ class ESPHomeClient(BaseBleakClient):
                 # A cancel that reached the inner task itself is not a
                 # caller cancellation to honor; only count the ones the
                 # shield absorbed on our behalf.
-                absorbed = not disconnect_task.cancelled()
+                absorbed = absorbed or not disconnect_task.cancelled()
             except Exception:  # pylint: disable=broad-except
                 break
         if disconnect_task.cancelled():
@@ -329,7 +341,7 @@ class ESPHomeClient(BaseBleakClient):
                     "%s: Releasing orphaned ESP-side connection",
                     self._description,
                 )
-                orphan_task = self._loop.create_task(self._shielded_disconnect())
+                orphan_task = self._loop.create_task(self._release_orphaned_link())
                 self._orphan_disconnect_tasks.add(orphan_task)
                 orphan_task.add_done_callback(self._on_orphan_release_done)
             return
@@ -529,15 +541,23 @@ class ESPHomeClient(BaseBleakClient):
         await self._disconnect_no_wait()
         await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
 
-    async def _disconnect_no_wait(self) -> None:
-        """Release the ESP-side connection without the free-slot wait."""
+    async def _disconnect_no_wait(self, timeout: float | None = None) -> None:
+        """
+        Release the ESP-side connection without the free-slot wait.
+
+        ``timeout`` bounds the disconnect RPC; the shielded cleanup paths
+        pass a short one because they absorb cancellation for the whole
+        RPC, while the public ``disconnect()`` path keeps aioesphomeapi's
+        default so a congested proxy is not turned into a spurious
+        ``TimeoutError``.
+        """
         try:
-            # Bound explicitly: the shielded cleanup paths absorb
-            # cancellation for the whole RPC, so aioesphomeapi's 20s
-            # default would make an uncancellable window that long.
-            await self._client.bluetooth_device_disconnect(
-                self._address_as_int, timeout=DISCONNECT_TIMEOUT
-            )
+            if timeout is None:
+                await self._client.bluetooth_device_disconnect(self._address_as_int)
+            else:
+                await self._client.bluetooth_device_disconnect(
+                    self._address_as_int, timeout=timeout
+                )
         finally:
             self._async_ble_device_disconnected()
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -234,11 +234,12 @@ class ESPHomeClient(BaseBleakClient):
         Sends the disconnect synchronously so cleanup and cancellation
         paths have nothing to await and no uncancellable window; the ESP
         frees the slot when it processes the request and reports the
-        state change through the usual subscriptions. A failed send is a
-        leaked proxy slot, so it is logged as a warning rather than
-        swallowed silently. Local state is torn down either way. Returns
-        True when the request was actually sent, so callers can skip
-        settling for a slot that cannot free.
+        state change through the usual subscriptions. A failed send means
+        a leaked proxy slot and warns; a dead API connection is the
+        exception and logs at debug, since the proxy releases every link
+        it holds once its subscriber is gone. Local state is torn down
+        either way. Returns True when the request was actually sent, so
+        callers can skip settling for a slot that cannot free.
         """
         sent = False
         try:
@@ -258,6 +259,7 @@ class ESPHomeClient(BaseBleakClient):
                 "may stay allocated until it disconnects on its own: %s",
                 self._description,
                 exc,
+                exc_info=True,
             )
         # Local teardown without consumer notification: an abandoned
         # attempt never handed the consumer a connected client, so it
@@ -430,89 +432,101 @@ class ESPHomeClient(BaseBleakClient):
         connected_future: asyncio.Future[bool] = self._loop.create_future()
 
         timeout = kwargs.get("timeout", self._timeout)
-        with self._scanner.connecting():
-            try:
-                self._cancel_connection_state = (
-                    await self._client.bluetooth_device_connect(
-                        self._address_as_int,
-                        partial(self._on_bluetooth_connection_state, connected_future),
-                        timeout=timeout,
-                        has_cache=has_cache,
-                        feature_flags=self._feature_flags,
-                        address_type=self._address_type,
+        settle_needed = False
+        try:
+            with self._scanner.connecting():
+                try:
+                    self._cancel_connection_state = (
+                        await self._client.bluetooth_device_connect(
+                            self._address_as_int,
+                            partial(
+                                self._on_bluetooth_connection_state, connected_future
+                            ),
+                            timeout=timeout,
+                            has_cache=has_cache,
+                            feature_flags=self._feature_flags,
+                            address_type=self._address_type,
+                        )
                     )
-                )
-            except asyncio.CancelledError:
-                if connected_future.done():
+                except asyncio.CancelledError:
+                    if connected_future.done():
+                        self._retrieve_future_error(connected_future)
+                    else:
+                        # Make the abandoned attempt terminal so a late
+                        # connection-state callback cannot resurrect state.
+                        connected_future.cancel()
+                    # aioesphomeapi already told the ESP to drop the link in
+                    # its own failure handlers, but abandoning uniformly does
+                    # not rely on that; a duplicate release is harmless.
+                    self._abandon_connect_attempt()
+                    # If the current task is not actually being cancelled,
+                    # the cancellation came from inside (e.g. the
+                    # connect_future being cancelled externally). Convert
+                    # it to a BleakError so bleak_retry_connector's retry
+                    # logic can handle it instead of aborting the caller.
+                    if is_spurious_cancellation():
+                        raise BleakError(
+                            f"{self._description}: Connect attempt was cancelled"
+                        ) from None
+                    raise
+                except Exception as ex:
+                    if connected_future.done():
+                        # Prefer to raise the exception from the connect call
+                        # as it is more descriptive than a stored future error.
+                        self._retrieve_future_error(connected_future)
+                    else:
+                        connected_future.cancel(
+                            f"Unhandled exception in connect call: {ex}"
+                        )
+                    self._abandon_connect_attempt()
+                    raise
+                try:
+                    await connected_future
+                except asyncio.CancelledError:
                     self._retrieve_future_error(connected_future)
-                else:
-                    # Make the abandoned attempt terminal so a late
-                    # connection-state callback cannot resurrect state.
-                    connected_future.cancel()
-                # aioesphomeapi already told the ESP to drop the link in
-                # its own failure handlers, but abandoning uniformly does
-                # not rely on that; a duplicate release is harmless.
-                self._abandon_connect_attempt()
-                # If the current task is not actually being cancelled,
-                # the cancellation came from inside (e.g. the
-                # connect_future being cancelled externally). Convert
-                # it to a BleakError so bleak_retry_connector's retry
-                # logic can handle it instead of aborting the caller.
-                if is_spurious_cancellation():
-                    raise BleakError(
-                        f"{self._description}: Connect attempt was cancelled"
-                    ) from None
-                raise
-            except Exception as ex:
-                if connected_future.done():
-                    # Prefer to raise the exception from the connect call
-                    # as it is more descriptive than a stored future error.
-                    self._retrieve_future_error(connected_future)
-                else:
-                    connected_future.cancel(
-                        f"Unhandled exception in connect call: {ex}"
-                    )
-                self._abandon_connect_attempt()
-                raise
-            try:
-                await connected_future
-            except asyncio.CancelledError:
-                self._retrieve_future_error(connected_future)
-                # The cancellation may have been delivered after the link
-                # already came up (``connected_future`` can hold a result
-                # while the awaiting task was cancelled before resuming);
-                # release the ESP-side connection so the proxy's slot is
-                # not leaked on a connection no client owns.
-                self._abandon_connect_attempt()
-                # If the current task is not actually being cancelled,
-                # treat a cancellation of connected_future as a normal
-                # connection failure so bleak_retry_connector can retry
-                # rather than letting CancelledError leak to the caller.
-                if is_spurious_cancellation():
-                    raise BleakError(
-                        f"{self._description}: Connect attempt was cancelled"
-                    ) from None
-                raise
-            except Exception:
-                # The future can also fail after the link came up
-                # (``connected=True`` with an error code); release the
-                # ESP-side connection so the slot is not leaked, then
-                # let the slot settle before the retry connector tries
-                # again. A cancellation arriving during the settle
-                # propagates naturally and outranks the original error.
-                # Deliberately inside the ``connecting()`` pause: the
-                # settle concludes this attempt before the scanner is
-                # considered scanning again. It only runs when a release
-                # was actually sent; an attempt that never held a slot
-                # has nothing to settle and must not pause scanning.
-                if self._abandon_connect_attempt():
-                    await self._settle_slot_after_failure("failed connect")
-                raise
-            except BaseException:
-                # A real signal must not be stalled behind a slow proxy,
-                # so no settle here.
-                self._abandon_connect_attempt()
-                raise
+                    # The cancellation may have been delivered after the link
+                    # already came up (``connected_future`` can hold a result
+                    # while the awaiting task was cancelled before resuming);
+                    # release the ESP-side connection so the proxy's slot is
+                    # not leaked on a connection no client owns.
+                    self._abandon_connect_attempt()
+                    # If the current task is not actually being cancelled,
+                    # treat a cancellation of connected_future as a normal
+                    # connection failure so bleak_retry_connector can retry
+                    # rather than letting CancelledError leak to the caller.
+                    if is_spurious_cancellation():
+                        raise BleakError(
+                            f"{self._description}: Connect attempt was cancelled"
+                        ) from None
+                    raise
+                except Exception:
+                    # The future can also fail after the link came up
+                    # (``connected=True`` with an error code); release the
+                    # ESP-side connection so the slot is not leaked, then
+                    # let the slot settle before the retry connector tries
+                    # again. A cancellation arriving during the settle
+                    # propagates naturally and outranks the original error.
+                    # The settle happens outside the ``connecting()``
+                    # pause in the outer handler, and only when a release
+                    # was actually sent; an attempt that never held a
+                    # slot has nothing to settle for.
+                    settle_needed = self._abandon_connect_attempt()
+                    raise
+                except BaseException:
+                    # A real signal must not be stalled behind a slow proxy,
+                    # so no settle here.
+                    self._abandon_connect_attempt()
+                    raise
+        except BaseException:
+            if settle_needed:
+                # Outside the ``connecting()`` pause on purpose: the
+                # release is already sent, so nothing about the settle
+                # needs the scanner blanked for up to another
+                # DISCONNECT_TIMEOUT on a saturated proxy. Reached only
+                # from the Exception arm; cancellation paths re-raise
+                # with the flag unset and never await here.
+                await self._settle_slot_after_failure("failed connect")
+            raise
 
         try:
             if pair:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -219,11 +219,27 @@ class ESPHomeClient(BaseBleakClient):
             self._disconnected_callback()
             self._disconnected_callback = None
 
-    @staticmethod
-    def _retrieve_future_error(fut: asyncio.Future[bool]) -> None:
+    def _retrieve_future_error(self, fut: asyncio.Future[bool]) -> None:
         """Mark a stored error retrieved so asyncio does not warn about it."""
-        if fut.done() and not fut.cancelled():
-            fut.exception()
+        if fut.done() and not fut.cancelled() and (exc := fut.exception()):
+            # The caller is raising a more actionable error in its place;
+            # keep the discarded cause recoverable from the logs.
+            _LOGGER.debug(
+                "%s: Discarding stored connect error: %s", self._description, exc
+            )
+
+    def _on_orphan_release_done(self, task: asyncio.Task[bool]) -> None:
+        """Drop a finished orphan release and surface one that never ran."""
+        self._orphan_disconnect_tasks.discard(task)
+        if task.cancelled():
+            # Nothing else observes this fire-and-forget task; a cancel
+            # here (loop teardown mid-flight) means the ESP link may
+            # still be up.
+            _LOGGER.warning(
+                "%s: Orphaned ESP-side connection release was cancelled "
+                "before it completed, the proxy slot may stay allocated",
+                self._description,
+            )
 
     async def _shielded_disconnect(self) -> bool:
         """
@@ -231,28 +247,30 @@ class ESPHomeClient(BaseBleakClient):
 
         The release is shielded so a cancellation arriving while it runs
         cannot interrupt it half-way and leave the device connected on the
-        ESP side; when one does arrive the release is drained first and
+        ESP side; when one does arrive the release is drained (still
+        shielded, so a further cancel cannot reach the RPC either) and
         True is returned so the caller can honor the absorbed cancellation.
         The free-slot wait is skipped so cleanup cannot stall a
-        cancellation behind a slow proxy; release errors are logged and
-        swallowed.
+        cancellation behind a slow proxy. A release that fails is a leaked
+        proxy slot, so it is logged as a warning rather than swallowed
+        silently.
         """
         disconnect_task = asyncio.create_task(self._disconnect_no_wait())
         absorbed = False
-        with contextlib.suppress(Exception):
+        while True:
             try:
                 await asyncio.shield(disconnect_task)
+                break
             except asyncio.CancelledError:
+                # Keep draining under the shield: each further cancel is
+                # absorbed the same way, so the RPC always completes.
                 absorbed = True
-                with contextlib.suppress(Exception):
-                    await disconnect_task
-        if (
-            disconnect_task.done()
-            and not disconnect_task.cancelled()
-            and (exc := disconnect_task.exception())
-        ):
-            _LOGGER.debug(
-                "%s: Ignoring error releasing ESP-side connection: %s",
+            except Exception:  # pylint: disable=broad-except
+                break
+        if not disconnect_task.cancelled() and (exc := disconnect_task.exception()):
+            _LOGGER.warning(
+                "%s: Failed to release ESP-side connection, the proxy slot "
+                "may stay allocated until it disconnects on its own: %s",
                 self._description,
                 exc,
             )
@@ -294,7 +312,7 @@ class ESPHomeClient(BaseBleakClient):
                 )
                 orphan_task = self._loop.create_task(self._shielded_disconnect())
                 self._orphan_disconnect_tasks.add(orphan_task)
-                orphan_task.add_done_callback(self._orphan_disconnect_tasks.discard)
+                orphan_task.add_done_callback(self._on_orphan_release_done)
             return
 
         if connected:
@@ -461,13 +479,18 @@ class ESPHomeClient(BaseBleakClient):
             # side, but never let a disconnect failure mask the original
             # connect error. Shielded like the sibling cancel branches so
             # a cancellation arriving mid-release cannot leave the device
-            # connected; ``connect()`` re-checks free slots at entry, so
-            # the slot wait is not needed here.
+            # connected.
             if await self._shielded_disconnect():
                 # A cancellation was absorbed during the release; it
                 # outranks the original error for the caller, which
                 # stays visible as the cause.
                 raise asyncio.CancelledError from setup_error
+            # Not a cancellation path, so let the slot settle before the
+            # retry connector tries again; the retry's entry gate only
+            # waits CONNECT_FREE_SLOT_TIMEOUT and would raise on a slow
+            # proxy otherwise. Errors here must not mask the setup error.
+            with contextlib.suppress(Exception):
+                await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
             raise
 
     @api_error_as_bleak_error

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -248,13 +248,9 @@ class ESPHomeClient(BaseBleakClient):
         """
         Release the ESP-side connection without waiting for a response.
 
-        Sends the disconnect synchronously so cleanup and cancellation
-        paths have nothing to await and no uncancellable window; the ESP
-        frees the slot when it processes the request and reports the
-        state change through the usual subscriptions. Local state is
-        torn down either way; the except clauses below carry the
-        logging policy. Returns True when the request was actually
-        sent.
+        Synchronous so cancellation has no window to land mid release.
+        Local state is torn down either way; returns True when the
+        request was actually sent.
         """
         sent = False
         try:
@@ -276,12 +272,8 @@ class ESPHomeClient(BaseBleakClient):
                 exc,
                 exc_info=True,
             )
-        # Local teardown without consumer notification: an abandoned
-        # attempt never handed the consumer a connected client, so it
-        # must not fire (and permanently null) ``disconnected_callback``,
-        # which has to survive for a later successful connect on this
-        # instance. Real disconnects go through
-        # ``_async_ble_device_disconnected`` instead.
+        # No consumer notification: an abandoned attempt must not fire
+        # (and null) ``disconnected_callback``.
         self._async_disconnected_cleanup()
         return sent
 
@@ -289,12 +281,9 @@ class ESPHomeClient(BaseBleakClient):
         """
         Tear down an abandoned connect attempt.
 
-        Releases the ESP-side link when it came up, including a link up
-        the late-callback path deferred via ``_pending_release`` (the
-        release tears down local state itself); otherwise only the local
-        cleanup runs so the connection-state subscription does not leak.
-        Returns True when an ESP-side release was sent, so callers can
-        skip the slot settle for attempts that never held a slot.
+        Releases the ESP-side link when it came up (or was deferred via
+        ``_pending_release``); otherwise only the local cleanup runs.
+        Returns True when a release was sent.
         """
         if self._is_connected or self._pending_release:
             return self._release_connection_no_wait()
@@ -305,13 +294,9 @@ class ESPHomeClient(BaseBleakClient):
         """
         Wait for the freed slot to settle after a failed attempt.
 
-        The next attempt's entry gate in ``connect()`` only waits
-        ``CONNECT_FREE_SLOT_TIMEOUT`` and would raise on a slow proxy
-        otherwise, so the settle is capped to that same window; waiting
-        longer cannot help a gate that has already given up and only
-        delays surfacing the original error. A settle failure must not
-        mask that error, but it is the direct cause of the next gate
-        failing, so it is logged rather than dropped.
+        Capped to the same window as the next attempt's entry gate in
+        ``connect()``; a settle failure is logged, never raised, so it
+        cannot mask the original error.
         """
         try:
             await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
@@ -352,35 +337,21 @@ class ESPHomeClient(BaseBleakClient):
             self._async_ble_device_disconnected()
 
         if connected_future.done():
-            # The connect attempt already finished (timed out, failed, or
-            # was cancelled) so the owning ``connect()`` has bailed and
-            # cleanup may already have run. A late ``connected=True`` must
-            # not mark the client connected again: nobody owns it anymore
-            # and the state would never be corrected.
+            # The attempt already finished; a late ``connected=True`` must
+            # not mark an unowned client connected again.
             if connected and not self._is_connected:
                 if self._cancel_connection_state is None:
-                    # The ESP did just establish the link though (this is
-                    # not a duplicate callback on a live connection, and
-                    # no newer attempt on this instance has its
-                    # connection-state subscription installed; during the
-                    # brief RPC window before that, aioesphomeapi's own
-                    # failure handlers release the link). Release it so
-                    # the abandoned attempt does not pin a proxy slot.
+                    # No attempt owns this link; release it so it does not
+                    # pin a proxy slot.
                     _LOGGER.debug(
                         "%s: Releasing orphaned ESP-side connection",
                         self._description,
                     )
                     self._release_connection_no_wait()
                 else:
-                    # The subscription that delivered this callback is
-                    # still installed, so the owning ``connect()`` has not
-                    # unwound yet and its abandonment runs next. Flag the
-                    # release as pending so that abandonment sends it;
-                    # skipping silently here would leak the slot. A
-                    # dedicated flag rather than ``_is_connected`` so a
-                    # racing ``connected=False`` cannot fire the
-                    # consumer's disconnected_callback for a connection
-                    # the caller never owned.
+                    # The owning ``connect()`` is still unwinding; flag the
+                    # release for its abandonment. A dedicated flag so a
+                    # racing ``connected=False`` cannot look consumer owned.
                     _LOGGER.debug(
                         "%s: Link came up on an abandoned attempt; "
                         "deferring the release to its abandonment",
@@ -482,13 +453,8 @@ class ESPHomeClient(BaseBleakClient):
                         # Make the abandoned attempt terminal so a late
                         # connection-state callback cannot resurrect state.
                         connected_future.cancel()
-                    # aioesphomeapi already told the ESP to drop the link in
-                    # its own failure handlers, but abandoning uniformly does
-                    # not rely on that; a duplicate release is harmless.
-                    # Cancel-shaped exits deliberately never settle, even
-                    # when the spurious conversion below hands the caller
-                    # a retryable error; the next attempt's entry gate
-                    # performs the same wait, so nothing is lost.
+                    # A duplicate release is harmless. Cancel-shaped exits
+                    # never settle; the next entry gate waits anyway.
                     self._abandon_connect_attempt()
                     self._raise_if_spurious_cancellation()
                     raise
@@ -504,40 +470,28 @@ class ESPHomeClient(BaseBleakClient):
                     settle_needed = self._abandon_connect_attempt()
                     raise
                 except BaseException:
-                    # Only true ``BaseException``s reach this arm; they
-                    # bypass the outer ``except Exception`` so no settle
-                    # follows, and assigning ``settle_needed`` here would
-                    # only mislead. The link is still released.
+                    # True BaseExceptions bypass the outer settle; still
+                    # release the link.
                     self._abandon_connect_attempt()
                     raise
                 try:
                     await connected_future
                 except asyncio.CancelledError:
                     self._retrieve_future_error(connected_future)
-                    # The cancellation may have been delivered after the link
-                    # already came up (``connected_future`` can hold a result
-                    # while the awaiting task was cancelled before resuming);
-                    # release the ESP-side connection so the proxy's slot is
-                    # not leaked on a connection no client owns.
-                    # Cancel-shaped exits deliberately never settle, even
-                    # when the spurious conversion below hands the caller
-                    # a retryable error; the next attempt's entry gate
-                    # performs the same wait, so nothing is lost.
+                    # The cancel can land after the link came up; release
+                    # so the slot is not leaked. Cancel-shaped exits never
+                    # settle; the next entry gate waits anyway.
                     self._abandon_connect_attempt()
                     self._raise_if_spurious_cancellation()
                     raise
                 except BaseException:
-                    # The future can also fail after the link came up
-                    # (``connected=True`` with an error code); release
-                    # the ESP-side connection so the slot is not leaked.
+                    # The future can fail after the link came up; release
+                    # so the slot is not leaked.
                     settle_needed = self._abandon_connect_attempt()
                     raise
         except Exception:
-            # Outside the ``connecting()`` pause on purpose: the release
-            # is already sent, so nothing about the settle needs the
-            # scanner blanked for up to another CONNECT_FREE_SLOT_TIMEOUT
-            # on a saturated proxy. Cancellations and signals are not caught
-            # here, so they can never be stalled behind it.
+            # Settle outside the ``connecting()`` pause; cancels and
+            # signals bypass this handler and are never stalled behind it.
             if settle_needed:
                 await self._settle_slot_after_failure("failed connect")
             raise
@@ -549,15 +503,13 @@ class ESPHomeClient(BaseBleakClient):
                 dangerous_use_bleak_cache=dangerous_use_bleak_cache
             )
         except Exception:
-            # Best-effort cleanup: release the BLE connection on the ESP
-            # side, but never let a disconnect failure mask the original
-            # connect error, then let the slot settle before the retry.
+            # Release, then settle before the retry; never mask the
+            # original error.
             if self._abandon_connect_attempt():
                 await self._settle_slot_after_failure("failed connect setup")
             raise
         except BaseException:
-            # Cancellations and real signals must not be stalled behind
-            # the settle; the link is still released synchronously.
+            # No settle on cancels and signals; still release.
             self._abandon_connect_attempt()
             raise
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -160,7 +160,7 @@ class ESPHomeClient(BaseBleakClient):
         self._is_connected = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
-        self._orphan_disconnect_task: asyncio.Task[None] | None = None
+        self._orphan_disconnect_tasks: set[asyncio.Task[bool]] = set()
         self._notify_cancels: dict[
             int, tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]
         ] = {}
@@ -219,24 +219,44 @@ class ESPHomeClient(BaseBleakClient):
             self._disconnected_callback()
             self._disconnected_callback = None
 
-    async def _shielded_disconnect(self) -> None:
+    @staticmethod
+    def _retrieve_future_error(fut: asyncio.Future[bool]) -> None:
+        """Mark a stored error retrieved so asyncio does not warn about it."""
+        if fut.done() and not fut.cancelled():
+            fut.exception()
+
+    async def _shielded_disconnect(self) -> bool:
         """
         Release the ESP-side connection, surviving re-cancellation.
 
-        The disconnect is shielded so a cancellation arriving while it is
-        running cannot interrupt it half-way and leave the device connected
-        on the ESP side. If a re-cancellation does arrive, the disconnect is
-        drained best-effort before the cancellation propagates. Errors are
-        suppressed: this is cleanup on an already-failing path and the
-        original outcome is the actionable one for the caller.
+        The release is shielded so a cancellation arriving while it runs
+        cannot interrupt it half-way and leave the device connected on the
+        ESP side; when one does arrive the release is drained first and
+        True is returned so the caller can honor the absorbed cancellation.
+        The free-slot wait is skipped so cleanup cannot stall a
+        cancellation behind a slow proxy; release errors are logged and
+        swallowed.
         """
-        disconnect_task = asyncio.create_task(self._disconnect())
+        disconnect_task = asyncio.create_task(self._disconnect_no_wait())
+        absorbed = False
         with contextlib.suppress(Exception):
             try:
                 await asyncio.shield(disconnect_task)
             except asyncio.CancelledError:
+                absorbed = True
                 with contextlib.suppress(Exception):
                     await disconnect_task
+        if (
+            disconnect_task.done()
+            and not disconnect_task.cancelled()
+            and (exc := disconnect_task.exception())
+        ):
+            _LOGGER.debug(
+                "%s: Ignoring error releasing ESP-side connection: %s",
+                self._description,
+                exc,
+            )
+        return absorbed
 
     def _on_bluetooth_connection_state(
         self,
@@ -263,20 +283,18 @@ class ESPHomeClient(BaseBleakClient):
             # not mark the client connected again: nobody owns it anymore
             # and the state would never be corrected.
             if connected and not self._is_connected:
-                # The ESP did just establish the link though; release it
-                # so the abandoned attempt does not pin a proxy slot. Not
-                # taken for a duplicate callback on a live connection,
-                # where ``_is_connected`` is still set.
+                # The ESP did just establish the link though (this is not
+                # a duplicate callback on a live connection); release it
+                # so the abandoned attempt does not pin a proxy slot. The
+                # set anchors the task against garbage collection until
+                # it finishes.
                 _LOGGER.debug(
                     "%s: Releasing orphaned ESP-side connection",
                     self._description,
                 )
-                # Hold a reference so the task is not garbage collected
-                # before it runs; one connect attempt per client instance
-                # means at most one orphan release.
-                self._orphan_disconnect_task = self._loop.create_task(
-                    self._shielded_disconnect()
-                )
+                orphan_task = self._loop.create_task(self._shielded_disconnect())
+                self._orphan_disconnect_tasks.add(orphan_task)
+                orphan_task.add_done_callback(self._orphan_disconnect_tasks.discard)
             return
 
         if connected:
@@ -362,17 +380,11 @@ class ESPHomeClient(BaseBleakClient):
                     )
                 )
             except asyncio.CancelledError:
-                if connected_future.done():
-                    with contextlib.suppress(BleakError):
-                        # If we are cancelled while connecting,
-                        # we need to make sure we await the future
-                        # to avoid a warning about an un-retrieved
-                        # exception.
-                        await connected_future
-                else:
+                if not connected_future.done():
                     # Make the abandoned attempt terminal so a late
                     # connection-state callback cannot resurrect state.
                     connected_future.cancel()
+                self._retrieve_future_error(connected_future)
                 self._async_disconnected_cleanup()
                 # If the current task is not actually being cancelled,
                 # the cancellation came from inside (e.g. the
@@ -385,21 +397,16 @@ class ESPHomeClient(BaseBleakClient):
                     ) from None
                 raise
             except Exception as ex:
-                if connected_future.done():
-                    with contextlib.suppress(BleakError):
-                        # If the connect call throws an exception,
-                        # we need to make sure we await the future
-                        # to avoid a warning about an un-retrieved
-                        # exception since we prefer to raise the
-                        # exception from the connect call as it
-                        # will be more descriptive.
-                        await connected_future
+                # Prefer to raise the exception from the connect call as
+                # it will be more descriptive than a stored future error.
+                self._retrieve_future_error(connected_future)
                 connected_future.cancel(f"Unhandled exception in connect call: {ex}")
                 self._async_disconnected_cleanup()
                 raise
             try:
                 await connected_future
             except asyncio.CancelledError:
+                self._retrieve_future_error(connected_future)
                 # The cancellation may have been delivered after the link
                 # already came up (``connected_future`` can hold a result
                 # while the awaiting task was cancelled before resuming);
@@ -421,13 +428,19 @@ class ESPHomeClient(BaseBleakClient):
                         f"{self._description}: Connect attempt was cancelled"
                     ) from None
                 raise
-            except BaseException:
+            except BaseException as connect_error:
                 # The future can also fail after the link came up
                 # (``connected=True`` with an error code); release the
                 # ESP-side connection so the slot is not leaked.
-                if self._is_connected:
-                    await self._shielded_disconnect()
+                absorbed_cancel = (
+                    self._is_connected and await self._shielded_disconnect()
+                )
                 self._async_disconnected_cleanup()
+                if absorbed_cancel:
+                    # A cancellation was absorbed while releasing the
+                    # link; it outranks the original error for the
+                    # caller, which stays visible as the cause.
+                    raise asyncio.CancelledError from connect_error
                 raise
 
         try:
@@ -443,16 +456,18 @@ class ESPHomeClient(BaseBleakClient):
             # before re-raising.
             await self._shielded_disconnect()
             raise
-        except Exception:
+        except Exception as setup_error:
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
-            # connect error. The original exception is the actionable one
-            # for the caller and bleak_retry_connector's retry logic; a
-            # failing cleanup disconnect would otherwise replace it. This
-            # mirrors the CancelledError branch above, which also
-            # suppresses disconnect errors during cleanup.
-            with contextlib.suppress(Exception):
-                await self._disconnect()
+            # connect error. Shielded like the sibling cancel branches so
+            # a cancellation arriving mid-release cannot leave the device
+            # connected; ``connect()`` re-checks free slots at entry, so
+            # the slot wait is not needed here.
+            if await self._shielded_disconnect():
+                # A cancellation was absorbed during the release; it
+                # outranks the original error for the caller, which
+                # stays visible as the cause.
+                raise asyncio.CancelledError from setup_error
             raise
 
     @api_error_as_bleak_error
@@ -460,13 +475,16 @@ class ESPHomeClient(BaseBleakClient):
         """Disconnect from the peripheral device."""
         await self._disconnect()
 
-    async def _disconnect(self) -> bool:
+    async def _disconnect(self) -> None:
+        await self._disconnect_no_wait()
+        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+
+    async def _disconnect_no_wait(self) -> None:
+        """Release the ESP-side connection without the free-slot wait."""
         try:
             await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
-        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-        return True
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -158,6 +158,7 @@ class ESPHomeClient(BaseBleakClient):
         self._bluetooth_device = client_data.bluetooth_device
         self._client = client_data.client
         self._is_connected = False
+        self._pending_release = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
         self._notify_cancels: dict[
@@ -185,6 +186,7 @@ class ESPHomeClient(BaseBleakClient):
         """Clean up on disconnect."""
         self.services = BleakGATTServiceCollection()
         self._is_connected = False
+        self._pending_release = False
         for _, notify_abort in self._notify_cancels.values():
             notify_abort()
         self._notify_cancels.clear()
@@ -287,13 +289,14 @@ class ESPHomeClient(BaseBleakClient):
         """
         Tear down an abandoned connect attempt.
 
-        Releases the ESP-side link when it came up (the release tears
-        down local state itself); otherwise only the local cleanup runs
-        so the connection-state subscription does not leak. Returns True
-        when an ESP-side release was sent, so callers can skip the slot
-        settle for attempts that never held a slot.
+        Releases the ESP-side link when it came up, including a link up
+        the late-callback path deferred via ``_pending_release`` (the
+        release tears down local state itself); otherwise only the local
+        cleanup runs so the connection-state subscription does not leak.
+        Returns True when an ESP-side release was sent, so callers can
+        skip the slot settle for attempts that never held a slot.
         """
-        if self._is_connected:
+        if self._is_connected or self._pending_release:
             return self._release_connection_no_wait()
         self._async_disconnected_cleanup()
         return False
@@ -371,16 +374,19 @@ class ESPHomeClient(BaseBleakClient):
                 else:
                     # The subscription that delivered this callback is
                     # still installed, so the owning ``connect()`` has not
-                    # unwound yet and its abandonment runs next. Mark the
-                    # link up so that abandonment releases it; skipping
-                    # silently here would leak the slot, since the
-                    # abandonment only releases when the link came up.
+                    # unwound yet and its abandonment runs next. Flag the
+                    # release as pending so that abandonment sends it;
+                    # skipping silently here would leak the slot. A
+                    # dedicated flag rather than ``_is_connected`` so a
+                    # racing ``connected=False`` cannot fire the
+                    # consumer's disconnected_callback for a connection
+                    # the caller never owned.
                     _LOGGER.debug(
                         "%s: Link came up on an abandoned attempt; "
                         "deferring the release to its abandonment",
                         self._description,
                     )
-                    self._is_connected = True
+                    self._pending_release = True
             return
 
         if connected:
@@ -494,7 +500,11 @@ class ESPHomeClient(BaseBleakClient):
                     settle_needed = self._abandon_connect_attempt()
                     raise
                 except BaseException:
-                    settle_needed = self._abandon_connect_attempt()
+                    # Only true ``BaseException``s reach this arm; they
+                    # bypass the outer ``except Exception`` so no settle
+                    # follows, and assigning ``settle_needed`` here would
+                    # only mislead. The link is still released.
+                    self._abandon_connect_attempt()
                     raise
                 try:
                     await connected_future
@@ -517,8 +527,8 @@ class ESPHomeClient(BaseBleakClient):
         except Exception:
             # Outside the ``connecting()`` pause on purpose: the release
             # is already sent, so nothing about the settle needs the
-            # scanner blanked for up to another DISCONNECT_TIMEOUT on a
-            # saturated proxy. Cancellations and signals are not caught
+            # scanner blanked for up to another CONNECT_FREE_SLOT_TIMEOUT
+            # on a saturated proxy. Cancellations and signals are not caught
             # here, so they can never be stalled behind it.
             if settle_needed:
                 await self._settle_slot_after_failure("failed connect")

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -327,7 +327,7 @@ class ESPHomeClient(BaseBleakClient):
             # Anything else is a defect in the wait path, not a slow
             # proxy; it must not hide at debug.
             _LOGGER.warning(
-                "%s: Unexpected error while waiting for the slot to " "settle after %s",
+                "%s: Unexpected error while waiting for the slot to settle after %s",
                 self._description,
                 context,
                 exc_info=True,
@@ -485,6 +485,10 @@ class ESPHomeClient(BaseBleakClient):
                     # aioesphomeapi already told the ESP to drop the link in
                     # its own failure handlers, but abandoning uniformly does
                     # not rely on that; a duplicate release is harmless.
+                    # Cancel-shaped exits deliberately never settle, even
+                    # when the spurious conversion below hands the caller
+                    # a retryable error; the next attempt's entry gate
+                    # performs the same wait, so nothing is lost.
                     self._abandon_connect_attempt()
                     self._raise_if_spurious_cancellation()
                     raise
@@ -515,6 +519,10 @@ class ESPHomeClient(BaseBleakClient):
                     # while the awaiting task was cancelled before resuming);
                     # release the ESP-side connection so the proxy's slot is
                     # not leaked on a connection no client owns.
+                    # Cancel-shaped exits deliberately never settle, even
+                    # when the spurious conversion below hands the caller
+                    # a retryable error; the next attempt's entry gate
+                    # performs the same wait, so nothing is lost.
                     self._abandon_connect_attempt()
                     self._raise_if_spurious_cancellation()
                     raise

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -218,6 +218,21 @@ class ESPHomeClient(BaseBleakClient):
             self._disconnected_callback()
             self._disconnected_callback = None
 
+    def _raise_if_spurious_cancellation(self) -> None:
+        """
+        Convert a spurious cancellation into a retryable error.
+
+        If the current task is not actually being cancelled, the
+        ``CancelledError`` came from inside (for example the connect
+        future being cancelled externally); convert it to a
+        ``BleakError`` so bleak_retry_connector's retry logic can handle
+        it instead of aborting the caller.
+        """
+        if is_spurious_cancellation():
+            raise BleakError(
+                f"{self._description}: Connect attempt was cancelled"
+            ) from None
+
     def _retrieve_future_error(self, fut: asyncio.Future[bool]) -> None:
         """Mark a stored error retrieved so asyncio does not warn about it."""
         if fut.done() and not fut.cancelled() and (exc := fut.exception()):
@@ -234,12 +249,10 @@ class ESPHomeClient(BaseBleakClient):
         Sends the disconnect synchronously so cleanup and cancellation
         paths have nothing to await and no uncancellable window; the ESP
         frees the slot when it processes the request and reports the
-        state change through the usual subscriptions. A failed send means
-        a leaked proxy slot and warns; a dead API connection is the
-        exception and logs at debug, since the proxy releases every link
-        it holds once its subscriber is gone. Local state is torn down
-        either way. Returns True when the request was actually sent, so
-        callers can skip settling for a slot that cannot free.
+        state change through the usual subscriptions. Local state is
+        torn down either way; the except clauses below carry the
+        logging policy. Returns True when the request was actually
+        sent.
         """
         sent = False
         try:
@@ -281,10 +294,6 @@ class ESPHomeClient(BaseBleakClient):
         settle for attempts that never held a slot.
         """
         if self._is_connected:
-            # Settle only when the request went out; a failed send (a
-            # dead API connection above all) means ``free`` can never
-            # update over that same connection, so waiting would stall
-            # for the full timeout with scanning paused.
             return self._release_connection_no_wait()
         self._async_disconnected_cleanup()
         return False
@@ -459,15 +468,7 @@ class ESPHomeClient(BaseBleakClient):
                     # its own failure handlers, but abandoning uniformly does
                     # not rely on that; a duplicate release is harmless.
                     self._abandon_connect_attempt()
-                    # If the current task is not actually being cancelled,
-                    # the cancellation came from inside (e.g. the
-                    # connect_future being cancelled externally). Convert
-                    # it to a BleakError so bleak_retry_connector's retry
-                    # logic can handle it instead of aborting the caller.
-                    if is_spurious_cancellation():
-                        raise BleakError(
-                            f"{self._description}: Connect attempt was cancelled"
-                        ) from None
+                    self._raise_if_spurious_cancellation()
                     raise
                 except Exception as ex:
                     if connected_future.done():
@@ -478,7 +479,10 @@ class ESPHomeClient(BaseBleakClient):
                         connected_future.cancel(
                             f"Unhandled exception in connect call: {ex}"
                         )
-                    self._abandon_connect_attempt()
+                    settle_needed = self._abandon_connect_attempt()
+                    raise
+                except BaseException:
+                    settle_needed = self._abandon_connect_attempt()
                     raise
                 try:
                     await connected_future
@@ -490,41 +494,21 @@ class ESPHomeClient(BaseBleakClient):
                     # release the ESP-side connection so the proxy's slot is
                     # not leaked on a connection no client owns.
                     self._abandon_connect_attempt()
-                    # If the current task is not actually being cancelled,
-                    # treat a cancellation of connected_future as a normal
-                    # connection failure so bleak_retry_connector can retry
-                    # rather than letting CancelledError leak to the caller.
-                    if is_spurious_cancellation():
-                        raise BleakError(
-                            f"{self._description}: Connect attempt was cancelled"
-                        ) from None
-                    raise
-                except Exception:
-                    # The future can also fail after the link came up
-                    # (``connected=True`` with an error code); release the
-                    # ESP-side connection so the slot is not leaked, then
-                    # let the slot settle before the retry connector tries
-                    # again. A cancellation arriving during the settle
-                    # propagates naturally and outranks the original error.
-                    # The settle happens outside the ``connecting()``
-                    # pause in the outer handler, and only when a release
-                    # was actually sent; an attempt that never held a
-                    # slot has nothing to settle for.
-                    settle_needed = self._abandon_connect_attempt()
+                    self._raise_if_spurious_cancellation()
                     raise
                 except BaseException:
-                    # A real signal must not be stalled behind a slow proxy,
-                    # so no settle here.
-                    self._abandon_connect_attempt()
+                    # The future can also fail after the link came up
+                    # (``connected=True`` with an error code); release
+                    # the ESP-side connection so the slot is not leaked.
+                    settle_needed = self._abandon_connect_attempt()
                     raise
-        except BaseException:
+        except Exception:
+            # Outside the ``connecting()`` pause on purpose: the release
+            # is already sent, so nothing about the settle needs the
+            # scanner blanked for up to another DISCONNECT_TIMEOUT on a
+            # saturated proxy. Cancellations and signals are not caught
+            # here, so they can never be stalled behind it.
             if settle_needed:
-                # Outside the ``connecting()`` pause on purpose: the
-                # release is already sent, so nothing about the settle
-                # needs the scanner blanked for up to another
-                # DISCONNECT_TIMEOUT on a saturated proxy. Reached only
-                # from the Exception arm; cancellation paths re-raise
-                # with the flag unset and never await here.
                 await self._settle_slot_after_failure("failed connect")
             raise
 
@@ -534,13 +518,6 @@ class ESPHomeClient(BaseBleakClient):
             await self._get_services(
                 dangerous_use_bleak_cache=dangerous_use_bleak_cache
             )
-        except asyncio.CancelledError:
-            # On cancel we must still raise CancelledError to avoid
-            # blocking the cancellation even if the disconnect call
-            # fails, so release the ESP-side connection synchronously
-            # before re-raising.
-            self._abandon_connect_attempt()
-            raise
         except Exception:
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
@@ -549,8 +526,8 @@ class ESPHomeClient(BaseBleakClient):
                 await self._settle_slot_after_failure("failed connect setup")
             raise
         except BaseException:
-            # A real signal must not be stalled behind a slow proxy,
-            # so no settle here; the link is still released.
+            # Cancellations and real signals must not be stalled behind
+            # the settle; the link is still released synchronously.
             self._abandon_connect_attempt()
             raise
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -235,6 +235,20 @@ class ESPHomeClient(BaseBleakClient):
                 f"{self._description}: Connect attempt was cancelled"
             ) from None
 
+    def _normalize_connect_future(
+        self, fut: asyncio.Future[bool], msg: str | None = None
+    ) -> None:
+        """
+        Make an abandoned attempt's future terminal and retrieved.
+
+        A pending future left behind would let a late ``connected=True``
+        take the success path and resurrect the abandoned client.
+        """
+        if fut.done():
+            self._retrieve_future_error(fut)
+        else:
+            fut.cancel(msg)
+
     def _retrieve_future_error(self, fut: asyncio.Future[bool]) -> None:
         """Mark a stored error retrieved so asyncio does not warn about it."""
         if fut.done() and not fut.cancelled() and (exc := fut.exception()):
@@ -448,41 +462,31 @@ class ESPHomeClient(BaseBleakClient):
                         )
                     )
                 except asyncio.CancelledError:
-                    if connected_future.done():
-                        self._retrieve_future_error(connected_future)
-                    else:
-                        # Make the abandoned attempt terminal so a late
-                        # connection-state callback cannot resurrect state.
-                        connected_future.cancel()
+                    self._normalize_connect_future(connected_future)
                     # A duplicate release is harmless. Cancel-shaped exits
                     # never settle; the next entry gate waits anyway.
                     self._abandon_connect_attempt()
                     self._raise_if_spurious_cancellation()
                     raise
                 except Exception as ex:
-                    if connected_future.done():
-                        # Prefer to raise the exception from the connect call
-                        # as it is more descriptive than a stored future error.
-                        self._retrieve_future_error(connected_future)
-                    else:
-                        connected_future.cancel(
-                            f"Unhandled exception in connect call: {ex}"
-                        )
+                    # The connect call's error is preferred over a stored
+                    # future error as it is more descriptive.
+                    self._normalize_connect_future(
+                        connected_future,
+                        f"Unhandled exception in connect call: {ex}",
+                    )
                     settle_needed = self._abandon_connect_attempt()
                     raise
                 except BaseException:
                     # True BaseExceptions bypass the outer settle; still
                     # release the link and normalize the future.
-                    if connected_future.done():
-                        self._retrieve_future_error(connected_future)
-                    else:
-                        connected_future.cancel()
+                    self._normalize_connect_future(connected_future)
                     self._abandon_connect_attempt()
                     raise
                 try:
                     await connected_future
                 except asyncio.CancelledError:
-                    self._retrieve_future_error(connected_future)
+                    self._normalize_connect_future(connected_future)
                     # The cancel can land after the link came up; release
                     # so the slot is not leaked. Cancel-shaped exits never
                     # settle; the next entry gate waits anyway.
@@ -492,6 +496,7 @@ class ESPHomeClient(BaseBleakClient):
                 except BaseException:
                     # The future can fail after the link came up; release
                     # so the slot is not leaked.
+                    self._normalize_connect_future(connected_future)
                     settle_needed = self._abandon_connect_attempt()
                     raise
         except Exception:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
 DEFAULT_MTU = 23
 GATT_HEADER_SIZE = 3
 DISCONNECT_TIMEOUT = 5.0
-SHIELDED_DISCONNECT_TIMEOUT = 5.0
 CONNECT_FREE_SLOT_TIMEOUT = 2.0
 GATT_READ_TIMEOUT = 30.0
 DEFAULT_TIMEOUT = 30.0
@@ -161,7 +160,6 @@ class ESPHomeClient(BaseBleakClient):
         self._is_connected = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
-        self._orphan_disconnect_tasks: set[asyncio.Task[bool]] = set()
         self._notify_cancels: dict[
             int, tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]
         ] = {}
@@ -229,84 +227,27 @@ class ESPHomeClient(BaseBleakClient):
                 "%s: Discarding stored connect error: %s", self._description, exc
             )
 
-    def _on_orphan_release_done(self, task: asyncio.Task[bool]) -> None:
-        """Drop a finished orphan release and surface one that blew up."""
-        self._orphan_disconnect_tasks.discard(task)
-        # Nothing else observes this fire-and-forget task. A cancelled or
-        # failed release is reported by _shielded_disconnect itself; the
-        # wrapper can only end cancelled before its first step, or fail on
-        # something escaping that helper, and neither must go unretrieved.
-        if task.cancelled():
-            _LOGGER.warning(
-                "%s: Orphaned ESP-side connection release was cancelled "
-                "before it started, the proxy slot may stay allocated",
-                self._description,
-            )
-        elif exc := task.exception():
-            _LOGGER.warning(
-                "%s: Orphaned ESP-side connection release failed, the proxy "
-                "slot may stay allocated: %s",
-                self._description,
-                exc,
-            )
-
-    async def _release_orphaned_link(self) -> bool:
-        """Release an orphaned link unless a newer connect owns it now."""
-        if self._is_connected or self._cancel_connection_state is not None:
-            # A newer connect on this client instance established a live
-            # link for the same address, or has an attempt in flight
-            # (bleak_retry_connector retries on the same instance);
-            # releasing by address now would tear that attempt down.
-            return False
-        return await self._shielded_disconnect()
-
-    async def _shielded_disconnect(self) -> bool:
+    def _release_connection_no_wait(self) -> None:
         """
-        Release the ESP-side connection, surviving re-cancellation.
+        Release the ESP-side connection without waiting for a response.
 
-        The release is shielded so a cancellation arriving while it runs
-        cannot interrupt it half-way and leave the device connected on the
-        ESP side; when one does arrive the release is drained (still
-        shielded, so a further cancel cannot reach the RPC either) and
-        True is returned so the caller can honor the absorbed cancellation.
-        The free-slot wait is skipped so cleanup cannot stall a
-        cancellation behind a slow proxy. A release that fails or is
-        itself cancelled (loop teardown) is a leaked proxy slot, so it is
-        logged as a warning rather than swallowed silently.
+        Sends the disconnect synchronously so cleanup and cancellation
+        paths have nothing to await and no uncancellable window; the ESP
+        frees the slot when it processes the request and reports the
+        state change through the usual subscriptions. A failed send is a
+        leaked proxy slot, so it is logged as a warning rather than
+        swallowed silently. Local state is torn down either way.
         """
-        disconnect_task = asyncio.create_task(
-            self._disconnect_no_wait(SHIELDED_DISCONNECT_TIMEOUT)
-        )
-        absorbed = False
-        # Loop on the inner task's state, not on the awaits: once the
-        # inner task is done a shield returns it directly and awaiting a
-        # cancelled task raises without yielding, so a while True here
-        # would spin and starve the loop.
-        while not disconnect_task.done():
-            try:
-                await asyncio.shield(disconnect_task)
-            except asyncio.CancelledError:
-                # A cancel that reached the inner task itself is not a
-                # caller cancellation to honor; only count the ones the
-                # shield absorbed on our behalf.
-                absorbed = absorbed or not disconnect_task.cancelled()
-            except Exception:  # pylint: disable=broad-except
-                break
-        if disconnect_task.cancelled():
-            _LOGGER.warning(
-                "%s: ESP-side connection release was cancelled before it "
-                "completed, the proxy slot may stay allocated until the "
-                "proxy disconnects on its own",
-                self._description,
-            )
-        elif exc := disconnect_task.exception():
+        try:
+            self._client.bluetooth_device_disconnect_no_wait(self._address_as_int)
+        except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.warning(
                 "%s: Failed to release ESP-side connection, the proxy slot "
                 "may stay allocated until it disconnects on its own: %s",
                 self._description,
                 exc,
             )
-        return absorbed
+        self._async_ble_device_disconnected()
 
     def _on_bluetooth_connection_state(
         self,
@@ -332,19 +273,20 @@ class ESPHomeClient(BaseBleakClient):
             # cleanup may already have run. A late ``connected=True`` must
             # not mark the client connected again: nobody owns it anymore
             # and the state would never be corrected.
-            if connected and not self._is_connected:
+            if (
+                connected
+                and not self._is_connected
+                and self._cancel_connection_state is None
+            ):
                 # The ESP did just establish the link though (this is not
-                # a duplicate callback on a live connection); release it
-                # so the abandoned attempt does not pin a proxy slot. The
-                # set anchors the task against garbage collection until
-                # it finishes.
+                # a duplicate callback on a live connection, and no newer
+                # attempt is in flight on this instance); release it so
+                # the abandoned attempt does not pin a proxy slot.
                 _LOGGER.debug(
                     "%s: Releasing orphaned ESP-side connection",
                     self._description,
                 )
-                orphan_task = self._loop.create_task(self._release_orphaned_link())
-                self._orphan_disconnect_tasks.add(orphan_task)
-                orphan_task.add_done_callback(self._on_orphan_release_done)
+                self._release_connection_no_wait()
             return
 
         if connected:
@@ -463,7 +405,7 @@ class ESPHomeClient(BaseBleakClient):
                 # release the ESP-side connection so the proxy's slot is
                 # not leaked on a connection no client owns.
                 if self._is_connected:
-                    await self._shielded_disconnect()
+                    self._release_connection_no_wait()
                 # Clean up local state and the connection-state
                 # subscription so it does not leak and trigger the
                 # ``not properly disconnected before destruction``
@@ -482,15 +424,12 @@ class ESPHomeClient(BaseBleakClient):
                 # The future can also fail after the link came up
                 # (``connected=True`` with an error code); release the
                 # ESP-side connection so the slot is not leaked.
-                absorbed_cancel = (
-                    self._is_connected and await self._shielded_disconnect()
-                )
+                # The release is synchronous, so no cancellation can
+                # land mid-release; one arriving during the settle below
+                # propagates naturally and outranks the original error.
+                if self._is_connected:
+                    self._release_connection_no_wait()
                 self._async_disconnected_cleanup()
-                if absorbed_cancel:
-                    # A cancellation was absorbed while releasing the
-                    # link; it outranks the original error for the
-                    # caller, which stays visible as the cause.
-                    raise asyncio.CancelledError from connect_error
                 if isinstance(connect_error, Exception):
                     # Same settle rationale as the setup-failure path:
                     # let the slot free up before the retry's short entry
@@ -515,27 +454,21 @@ class ESPHomeClient(BaseBleakClient):
         except asyncio.CancelledError:
             # On cancel we must still raise CancelledError to avoid
             # blocking the cancellation even if the disconnect call
-            # fails, so release the ESP-side connection best-effort
+            # fails, so release the ESP-side connection synchronously
             # before re-raising.
-            await self._shielded_disconnect()
+            self._release_connection_no_wait()
             raise
-        except Exception as setup_error:
+        except Exception:
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
-            # connect error. Shielded like the sibling cancel branches so
-            # a cancellation arriving mid-release cannot leave the device
-            # connected.
-            if await self._shielded_disconnect():
-                # A cancellation was absorbed during the release; it
-                # outranks the original error for the caller, which
-                # stays visible as the cause.
-                raise asyncio.CancelledError from setup_error
-            # Not a cancellation path, so let the slot settle before the
-            # retry connector tries again; the retry's entry gate only
-            # waits CONNECT_FREE_SLOT_TIMEOUT and would raise on a slow
-            # proxy otherwise. A settle failure must not mask the setup
-            # error, but it is the direct cause of that next gate failing,
-            # so it is logged rather than dropped.
+            # connect error. The release is synchronous, so a
+            # cancellation cannot interrupt it; one arriving during the
+            # settle below propagates naturally.
+            self._release_connection_no_wait()
+            # Let the slot settle before the retry connector tries
+            # again; the retry's entry gate only waits
+            # CONNECT_FREE_SLOT_TIMEOUT and would raise on a slow proxy
+            # otherwise. A settle failure must not mask the setup error.
             try:
                 await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
             except Exception as settle_error:  # pylint: disable=broad-except
@@ -555,23 +488,10 @@ class ESPHomeClient(BaseBleakClient):
         await self._disconnect_no_wait()
         await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
 
-    async def _disconnect_no_wait(self, timeout: float | None = None) -> None:
-        """
-        Release the ESP-side connection without the free-slot wait.
-
-        ``timeout`` bounds the disconnect RPC; the shielded cleanup paths
-        pass a short one because they absorb cancellation for the whole
-        RPC, while the public ``disconnect()`` path keeps aioesphomeapi's
-        default so a congested proxy is not turned into a spurious
-        ``TimeoutError``.
-        """
+    async def _disconnect_no_wait(self) -> None:
+        """Release the ESP-side connection without the free-slot wait."""
         try:
-            if timeout is None:
-                await self._client.bluetooth_device_disconnect(self._address_as_int)
-            else:
-                await self._client.bluetooth_device_disconnect(
-                    self._address_as_int, timeout=timeout
-                )
+            await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -249,6 +249,26 @@ class ESPHomeClient(BaseBleakClient):
             )
         self._async_ble_device_disconnected()
 
+    async def _settle_slot_after_failure(self, context: str) -> None:
+        """
+        Wait for the freed slot to settle after a failed attempt.
+
+        The retry connector's entry gate only waits
+        ``CONNECT_FREE_SLOT_TIMEOUT`` and would raise on a slow proxy
+        otherwise. A settle failure must not mask the original error,
+        but it is the direct cause of that next gate failing, so it is
+        logged rather than dropped.
+        """
+        try:
+            await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+        except Exception as settle_error:  # pylint: disable=broad-except
+            _LOGGER.debug(
+                "%s: Slot did not settle after %s: %s",
+                self._description,
+                context,
+                settle_error,
+            )
+
     def _on_bluetooth_connection_state(
         self,
         connected_future: asyncio.Future[bool],
@@ -372,11 +392,12 @@ class ESPHomeClient(BaseBleakClient):
                     )
                 )
             except asyncio.CancelledError:
-                if not connected_future.done():
+                if connected_future.done():
+                    self._retrieve_future_error(connected_future)
+                else:
                     # Make the abandoned attempt terminal so a late
                     # connection-state callback cannot resurrect state.
                     connected_future.cancel()
-                self._retrieve_future_error(connected_future)
                 self._async_disconnected_cleanup()
                 # If the current task is not actually being cancelled,
                 # the cancellation came from inside (e.g. the
@@ -389,10 +410,14 @@ class ESPHomeClient(BaseBleakClient):
                     ) from None
                 raise
             except Exception as ex:
-                # Prefer to raise the exception from the connect call as
-                # it will be more descriptive than a stored future error.
-                self._retrieve_future_error(connected_future)
-                connected_future.cancel(f"Unhandled exception in connect call: {ex}")
+                if connected_future.done():
+                    # Prefer to raise the exception from the connect call
+                    # as it is more descriptive than a stored future error.
+                    self._retrieve_future_error(connected_future)
+                else:
+                    connected_future.cancel(
+                        f"Unhandled exception in connect call: {ex}"
+                    )
                 self._async_disconnected_cleanup()
                 raise
             try:
@@ -403,14 +428,13 @@ class ESPHomeClient(BaseBleakClient):
                 # already came up (``connected_future`` can hold a result
                 # while the awaiting task was cancelled before resuming);
                 # release the ESP-side connection so the proxy's slot is
-                # not leaked on a connection no client owns.
+                # not leaked on a connection no client owns. The release
+                # tears down local state itself; otherwise clean up so
+                # the connection-state subscription does not leak.
                 if self._is_connected:
                     self._release_connection_no_wait()
-                # Clean up local state and the connection-state
-                # subscription so it does not leak and trigger the
-                # ``not properly disconnected before destruction``
-                # warning from ``__del__``.
-                self._async_disconnected_cleanup()
+                else:
+                    self._async_disconnected_cleanup()
                 # If the current task is not actually being cancelled,
                 # treat a cancellation of connected_future as a normal
                 # connection failure so bleak_retry_connector can retry
@@ -420,29 +444,26 @@ class ESPHomeClient(BaseBleakClient):
                         f"{self._description}: Connect attempt was cancelled"
                     ) from None
                 raise
-            except BaseException as connect_error:
+            except Exception:
                 # The future can also fail after the link came up
                 # (``connected=True`` with an error code); release the
-                # ESP-side connection so the slot is not leaked.
-                # The release is synchronous, so no cancellation can
-                # land mid-release; one arriving during the settle below
+                # ESP-side connection so the slot is not leaked, then
+                # let the slot settle before the retry connector tries
+                # again. A cancellation arriving during the settle
                 # propagates naturally and outranks the original error.
                 if self._is_connected:
                     self._release_connection_no_wait()
-                self._async_disconnected_cleanup()
-                if isinstance(connect_error, Exception):
-                    # Same settle rationale as the setup-failure path:
-                    # let the slot free up before the retry's short entry
-                    # gate. Skipped for BaseException so a real signal is
-                    # not stalled behind a slow proxy.
-                    try:
-                        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-                    except Exception as settle_error:  # pylint: disable=broad-except
-                        _LOGGER.debug(
-                            "%s: Slot did not settle after failed connect: %s",
-                            self._description,
-                            settle_error,
-                        )
+                else:
+                    self._async_disconnected_cleanup()
+                await self._settle_slot_after_failure("failed connect")
+                raise
+            except BaseException:
+                # A real signal must not be stalled behind a slow proxy,
+                # so no settle here.
+                if self._is_connected:
+                    self._release_connection_no_wait()
+                else:
+                    self._async_disconnected_cleanup()
                 raise
 
         try:
@@ -461,22 +482,9 @@ class ESPHomeClient(BaseBleakClient):
         except Exception:
             # Best-effort cleanup: release the BLE connection on the ESP
             # side, but never let a disconnect failure mask the original
-            # connect error. The release is synchronous, so a
-            # cancellation cannot interrupt it; one arriving during the
-            # settle below propagates naturally.
+            # connect error, then let the slot settle before the retry.
             self._release_connection_no_wait()
-            # Let the slot settle before the retry connector tries
-            # again; the retry's entry gate only waits
-            # CONNECT_FREE_SLOT_TIMEOUT and would raise on a slow proxy
-            # otherwise. A settle failure must not mask the setup error.
-            try:
-                await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-            except Exception as settle_error:  # pylint: disable=broad-except
-                _LOGGER.debug(
-                    "%s: Slot did not settle after failed connect setup: %s",
-                    self._description,
-                    settle_error,
-                )
+            await self._settle_slot_after_failure("failed connect setup")
             raise
 
     @api_error_as_bleak_error
@@ -485,15 +493,11 @@ class ESPHomeClient(BaseBleakClient):
         await self._disconnect()
 
     async def _disconnect(self) -> None:
-        await self._disconnect_no_wait()
-        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-
-    async def _disconnect_no_wait(self) -> None:
-        """Release the ESP-side connection without the free-slot wait."""
         try:
             await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
+        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/tests/backend/_helpers.py
+++ b/tests/backend/_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -82,7 +82,7 @@ def make_bleak_client(
 
 
 async def start_connect(
-    bleak_client: BleakClient, mock_connect: Any
+    connectable: Any, mock_connect: Any, **connect_kwargs: Any
 ) -> tuple[Any, Any]:
     """
     Start a ``connect()`` attempt and hand back its state callback.
@@ -91,14 +91,43 @@ async def start_connect(
     on ``connected_future``, and extracts the connection-state callback
     from the patched ``bluetooth_device_connect``. Centralizes the
     positional callback extraction so a change to the RPC's signature is
-    a one-place fix.
+    a one-place fix. ``connectable`` is anything with a ``connect``
+    coroutine (the ``BleakClient`` wrapper or the backend directly);
+    extra keyword arguments such as ``pair`` are forwarded to it.
     """
-    task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+    connect_kwargs.setdefault("dangerous_use_bleak_cache", True)
+    task = asyncio.create_task(connectable.connect(**connect_kwargs))
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     assert mock_connect.call_args_list, "bluetooth_device_connect was not called"
     callback = mock_connect.call_args_list[-1][0][1]
     return task, callback
+
+
+@contextmanager
+def patch_connect_rpcs(
+    client: ESPHomeClient, *, disconnect_side_effect: Any = None
+) -> Iterator[tuple[Any, Any]]:
+    """
+    Patch the connect and no-wait disconnect RPCs together.
+
+    Yields ``(mock_connect, mock_disconnect)``; the connect RPC returns a
+    plain ``Mock`` subscription handle and the disconnect mock optionally
+    raises ``disconnect_side_effect``.
+    """
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+            side_effect=disconnect_side_effect,
+        ) as mock_disconnect,
+    ):
+        yield mock_connect, mock_disconnect
 
 
 @contextmanager

--- a/tests/backend/_helpers.py
+++ b/tests/backend/_helpers.py
@@ -96,7 +96,8 @@ async def start_connect(
     task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
     await asyncio.sleep(0)
     await asyncio.sleep(0)
-    callback = mock_connect.call_args_list[0][0][1]
+    assert mock_connect.call_args_list, "bluetooth_device_connect was not called"
+    callback = mock_connect.call_args_list[-1][0][1]
     return task, callback
 
 

--- a/tests/backend/_helpers.py
+++ b/tests/backend/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -78,6 +79,25 @@ def make_bleak_client(
     backend: ESPHomeClient = bleak_client._backend
     backend._bluetooth_device.ble_connections_free = free_slots
     return bleak_client, backend
+
+
+async def start_connect(
+    bleak_client: BleakClient, mock_connect: Any
+) -> tuple[Any, Any]:
+    """
+    Start a ``connect()`` attempt and hand back its state callback.
+
+    Creates the connect task, settles the loop so the attempt is parked
+    on ``connected_future``, and extracts the connection-state callback
+    from the patched ``bluetooth_device_connect``. Centralizes the
+    positional callback extraction so a change to the RPC's signature is
+    a one-place fix.
+    """
+    task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    callback = mock_connect.call_args_list[0][0][1]
+    return task, callback
 
 
 @contextmanager

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -31,6 +31,7 @@ from ._helpers import (
     ESP_NAME,
     fetch_services,
     make_bleak_client,
+    patch_connect_rpcs,
     patch_get_services,
     start_connect,
 )
@@ -39,6 +40,30 @@ PRIMARY_CHAR_UUID = "090b7847-e12b-09a8-b04b-8e0922a9abab"
 INDICATE_CHAR_UUID = "00002a05-0000-1000-8000-00805f9b34fb"
 CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
 BLE_ADDRESS_AS_INT = 225106397622015
+
+
+class _Signal(BaseException):
+    """Stand-in for KeyboardInterrupt that pytest does not intercept."""
+
+
+async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+    """Fail service discovery with a retryable error."""
+    raise BleakError("services boom")
+
+
+def _capture_created_futures(
+    client: ESPHomeClient,
+) -> tuple[list["asyncio.Future[bool]"], Any]:
+    """Return a capture list and a create_future replacement to patch in."""
+    captured: list[asyncio.Future[bool]] = []
+    original_create_future = client._loop.create_future
+
+    def capturing_create_future() -> asyncio.Future[bool]:
+        fut = original_create_future()
+        captured.append(fut)
+        return fut
+
+    return captured, capturing_create_future
 
 
 def test_api_error_decorated_methods_preserve_metadata() -> None:
@@ -408,13 +433,7 @@ async def test_bleak_client_connect_connected_future_cancelled_raises_bleak_erro
     letting CancelledError propagate to the caller.
     """
     bleak_client, client = bleak_pair
-    original_create_future = client._loop.create_future
-    captured: list[asyncio.Future[bool]] = []
-
-    def capturing_create_future() -> asyncio.Future[bool]:
-        fut = original_create_future()
-        captured.append(fut)
-        return fut
+    captured, capturing_create_future = _capture_created_futures(client)
 
     mock_cancel_connection_state = Mock()
     with (
@@ -561,12 +580,7 @@ async def test_bleak_client_connect_settle_runs_with_scanning_resumed(
         scanning_during_settle.append(client._scanner.scanning)
 
     with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
+        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
         patch.object(
             client, "_settle_slot_after_failure", side_effect=_record_scanning
         ),
@@ -582,7 +596,6 @@ async def test_bleak_client_connect_settle_runs_with_scanning_resumed(
 @pytest.mark.asyncio
 async def test_bleak_client_connect_failed_release_skips_settle(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Test a failed release send skips the settle.
@@ -593,18 +606,10 @@ async def test_bleak_client_connect_failed_release_skips_settle(
     """
     bleak_client, client = bleak_pair
     with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-            side_effect=APIConnectionError("api gone"),
-        ),
+        patch_connect_rpcs(
+            client, disconnect_side_effect=APIConnectionError("api gone")
+        ) as (mock_connect, _mock_disconnect),
         patch.object(client, "_settle_slot_after_failure") as mock_settle,
-        caplog.at_level(logging.DEBUG),
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 1)
@@ -612,7 +617,6 @@ async def test_bleak_client_connect_failed_release_skips_settle(
             await task
 
     mock_settle.assert_not_awaited()
-    assert "ESP-side release skipped" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -628,12 +632,7 @@ async def test_bleak_client_connect_settle_defect_logged_as_warning(
     """
     bleak_client, client = bleak_pair
     with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
+        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
         patch.object(
             client,
             "_wait_for_free_connection_slot",
@@ -710,27 +709,14 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     disconnected_callback = Mock()
     client._disconnected_callback = disconnected_callback
 
-    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
-        raise BleakError("services boom")
-
-    with contextlib.ExitStack() as stack:
-        mock_connect = stack.enter_context(
-            patch.object(
-                client._client,
-                "bluetooth_device_connect",
-                return_value=Mock(),
-            )
-        )
-        stack.enter_context(
-            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
-        )
-        stack.enter_context(
-            patch.object(
-                client._client,
-                "bluetooth_gatt_get_services",
-                return_value=esphome_bluetooth_gatt_services,
-            )
-        )
+    with (
+        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
+        patch.object(
+            client._client,
+            "bluetooth_gatt_get_services",
+            return_value=esphome_bluetooth_gatt_services,
+        ),
+    ):
         # The failure injections live in their own scope so attempt 2
         # runs without them.
         with contextlib.ExitStack() as failure_stack:
@@ -753,12 +739,7 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
                     )
                 )
             # Attempt 1 fails; the consumer never saw a connected client.
-            task = asyncio.create_task(
-                client.connect(pair=pair, dangerous_use_bleak_cache=True)
-            )
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            callback = mock_connect.call_args_list[-1][0][1]
+            task, callback = await start_connect(client, mock_connect, pair=pair)
             callback(True, 23, 1 if failure_shape == "error_code" else 0)
             with pytest.raises(BleakError):
                 await task
@@ -788,17 +769,7 @@ async def test_bleak_client_connect_error_without_link_cleans_up_locally(
     is skipped since the attempt never held a slot.
     """
     bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-        ) as mock_disconnect,
-    ):
+    with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(False, 23, 1)
         with pytest.raises(BleakError, match="while connecting"):
@@ -820,18 +791,8 @@ async def test_bleak_client_connect_base_exception_releases_without_settle(
     delivered at the await) must not be stalled behind the slot settle;
     the link is still released so the proxy slot is not leaked.
     """
-
-    class _Signal(BaseException):
-        """Stand-in for KeyboardInterrupt that pytest does not intercept."""
-
     bleak_client, client = bleak_pair
-    original_create_future = client._loop.create_future
-    captured: list[asyncio.Future[bool]] = []
-
-    def capturing_create_future() -> asyncio.Future[bool]:
-        fut = original_create_future()
-        captured.append(fut)
-        return fut
+    captured, capturing_create_future = _capture_created_futures(client)
 
     with (
         patch.object(
@@ -860,8 +821,10 @@ async def test_bleak_client_connect_base_exception_releases_without_settle(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("error", [0, 1])
 async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
+    error: int,
 ) -> None:
     """
     Test cancellation delivered after the link already came up.
@@ -872,6 +835,8 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
     holds a live connection that no client owns. ``connect()`` must release
     it with the synchronous no-wait disconnect so the proxy's slot is not
     leaked, clean up local state, and still propagate the cancellation.
+    The ``error=1`` case additionally pins that a stored future error is
+    retrieved rather than left to warn at garbage collection.
     """
     bleak_client, client = bleak_pair
     mock_cancel_connection_state = Mock()
@@ -887,7 +852,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
         ) as mock_disconnect,
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
-        callback(True, 23, 0)
+        callback(True, 23, error)
         assert client._is_connected
         # Cancel before the awaiting task resumes: the future already has a
         # result, but Task._must_cancel still raises CancelledError at the
@@ -917,17 +882,7 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
     of leaking the proxy's slot.
     """
     bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-        ) as mock_disconnect,
-    ):
+    with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 1)
         with pytest.raises(BleakError, match="while connecting"):
@@ -972,16 +927,10 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
     """
     bleak_client, client = bleak_pair
     with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-            side_effect=release_error,
-        ) as mock_disconnect,
+        patch_connect_rpcs(client, disconnect_side_effect=release_error) as (
+            mock_connect,
+            mock_disconnect,
+        ),
         caplog.at_level(logging.DEBUG),
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
@@ -996,43 +945,6 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
     matching = [record for record in caplog.records if expected_text in record.message]
     assert len(matching) == 1
     assert matching[0].levelno == expected_level
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_cancel_after_error_retrieves_future(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test a cancel racing a stored connect error retrieves the error.
-
-    When the connection-state callback stores a ``BleakError`` and the
-    task is cancelled before resuming, the handler must retrieve the
-    stored exception (so asyncio does not log ``Future exception was
-    never retrieved``), release the link, and propagate the cancel.
-    """
-    bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-        ) as mock_disconnect,
-    ):
-        task, callback = await start_connect(bleak_client, mock_connect)
-        # connected with an error code: stores a BleakError on the future
-        # while _is_connected is already set.
-        callback(True, 23, 1)
-        assert task.cancel() is True
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        assert task.cancelled()
-
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
-    assert not client.is_connected
 
 
 @pytest.mark.asyncio
@@ -1165,22 +1077,38 @@ async def test_bleak_client_connect_outer_cancel_without_subscription(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_rpc_signal_cleans_up(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a signal raised by the connect RPC itself still tears down.
+
+    aioesphomeapi releases the ESP side in its own failure handlers; the
+    local abandonment must still run so the subscription and state do
+    not leak.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            side_effect=_Signal,
+        ),
+        pytest.raises(_Signal),
+    ):
+        await bleak_client.connect(dangerous_use_bleak_cache=True)
+
+    assert not client.is_connected
+    assert client._cancel_connection_state is None
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_outer_base_exception_cleans_up(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """A BaseException from the connection future still cleans up."""
-
-    class ConnectBaseException(BaseException):
-        """Sentinel exception that bypasses ``except Exception``."""
-
     bleak_client, client = bleak_pair
-    original_create_future = client._loop.create_future
-    captured: list[asyncio.Future[bool]] = []
-
-    def capturing_create_future() -> asyncio.Future[bool]:
-        fut = original_create_future()
-        captured.append(fut)
-        return fut
+    captured, capturing_create_future = _capture_created_futures(client)
 
     mock_cancel_connection_state = Mock()
     with (
@@ -1196,8 +1124,8 @@ async def test_bleak_client_connect_outer_base_exception_cleans_up(
         await asyncio.sleep(0)
         mock_connect.assert_called_once()
         assert len(captured) == 1
-        captured[0].set_exception(ConnectBaseException())
-        with pytest.raises(ConnectBaseException):
+        captured[0].set_exception(_Signal())
+        with pytest.raises(_Signal):
             await task
 
     assert not client.is_connected
@@ -1231,34 +1159,22 @@ async def test_bleak_client_connect_failure_logs_settle_timeout(
     """
     bleak_client, client = bleak_pair
 
-    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
-        raise BleakError("services boom")
-
-    with contextlib.ExitStack() as stack:
-        mock_connect = stack.enter_context(
-            patch.object(
-                client._client,
-                "bluetooth_device_connect",
-                return_value=Mock(),
-            )
-        )
-        stack.enter_context(
-            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
-        )
-        stack.enter_context(
-            patch.object(
-                client,
-                "_wait_for_free_connection_slot",
-                # First call is the connect entry gate; the second is the
-                # settle after the release, which times out.
-                side_effect=[None, TimeoutError("no slot")],
-            )
-        )
+    with (
+        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
+        patch.object(
+            client,
+            "_wait_for_free_connection_slot",
+            # First call is the connect entry gate; the second is the
+            # settle after the release, which times out.
+            side_effect=[None, TimeoutError("no slot")],
+        ),
+        contextlib.ExitStack() as failure_stack,
+        caplog.at_level(logging.DEBUG),
+    ):
         if services_boom:
-            stack.enter_context(
+            failure_stack.enter_context(
                 patch.object(client, "_get_services", side_effect=_boom_get_services)
             )
-        stack.enter_context(caplog.at_level(logging.DEBUG))
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0 if services_boom else 1)
         with pytest.raises(BleakError, match=expected_error):
@@ -1277,13 +1193,9 @@ async def test_bleak_client_connect_get_services_signal_releases_without_settle(
     A ``BaseException`` from the post-connect setup must not be stalled
     behind the slot settle; the link is still released.
     """
-
-    class _Signal(BaseException):
-        """Stand-in for KeyboardInterrupt that pytest does not intercept."""
-
     bleak_client, client = bleak_pair
 
-    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+    async def _boom_signal_get_services(*args: Any, **kwargs: Any) -> Any:
         raise _Signal
 
     with (
@@ -1292,7 +1204,7 @@ async def test_bleak_client_connect_get_services_signal_releases_without_settle(
             "bluetooth_device_connect",
             return_value=Mock(),
         ) as mock_connect,
-        patch.object(client, "_get_services", side_effect=_boom_get_services),
+        patch.object(client, "_get_services", side_effect=_boom_signal_get_services),
         patch.object(
             client._client,
             "bluetooth_device_disconnect_no_wait",
@@ -1382,11 +1294,7 @@ async def test_bleak_client_connect_get_services_failure_preserves_error(
             side_effect=RuntimeError("cleanup disconnect failed"),
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(
-            client.connect(pair=False, dangerous_use_bleak_cache=True)
-        )
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(client, mock_connect, pair=False)
         callback(True, 23, 0)
         with pytest.raises(BleakError) as exc_info:
             await task
@@ -1430,11 +1338,7 @@ async def test_bleak_client_connect_pair_failure_releases_slot(
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(
-            client.connect(pair=True, dangerous_use_bleak_cache=True)
-        )
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(client, mock_connect, pair=True)
         callback(True, 23, 0)
         with pytest.raises(BleakError, match="Pairing failed"):
             await task
@@ -1479,11 +1383,7 @@ async def test_bleak_client_connect_pair_failure_preserves_error(
             side_effect=RuntimeError("cleanup disconnect failed"),
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(
-            client.connect(pair=True, dangerous_use_bleak_cache=True)
-        )
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(client, mock_connect, pair=True)
         callback(True, 23, 0)
         with pytest.raises(BleakError) as exc_info:
             await task

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import inspect
 import logging
 from typing import Any
@@ -31,6 +32,7 @@ from ._helpers import (
     fetch_services,
     make_bleak_client,
     patch_get_services,
+    start_connect,
 )
 
 PRIMARY_CHAR_UUID = "090b7847-e12b-09a8-b04b-8e0922a9abab"
@@ -511,23 +513,118 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
     """
     bleak_client, client = bleak_pair
     mock_cancel_connection_state = Mock()
-    with patch.object(
-        client._client,
-        "bluetooth_device_connect",
-        return_value=mock_cancel_connection_state,
-    ) as mock_connect:
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        mock_connect.assert_called_once()
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=mock_cancel_connection_state,
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
         assert task.cancel() is True
         with pytest.raises(asyncio.CancelledError):
             await task
         assert task.cancelled()
 
+        assert not client.is_connected
+        mock_cancel_connection_state.assert_called_once_with()
+        assert client._cancel_connection_state is None
+
+        # A late ``connected=True`` for the abandoned attempt must not
+        # resurrect state and must release the link the ESP just
+        # established.
+        callback(True, 23, 0)
+        assert not client.is_connected
+        assert client._async_esp_disconnected not in client._disconnect_callbacks
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_error_without_link_cleans_up_locally(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a connect error with no link up skips the release.
+
+    A ``connected=False`` error resolution means the ESP holds nothing;
+    only the local cleanup runs, no disconnect is sent, and the settle
+    still runs before the retry.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(False, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    mock_disconnect.assert_not_called()
     assert not client.is_connected
-    mock_cancel_connection_state.assert_called_once_with()
     assert client._cancel_connection_state is None
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_base_exception_releases_without_settle(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a BaseException from the wait releases without settling.
+
+    A real signal (a ``BaseException`` such as ``KeyboardInterrupt``
+    delivered at the await) must not be stalled behind the slot settle;
+    the link is still released so the proxy slot is not leaked.
+    """
+
+    class _Signal(BaseException):
+        """Stand-in for KeyboardInterrupt that pytest does not intercept."""
+
+    bleak_client, client = bleak_pair
+    original_create_future = client._loop.create_future
+    captured: list[asyncio.Future[bool]] = []
+
+    def capturing_create_future() -> asyncio.Future[bool]:
+        fut = original_create_future()
+        captured.append(fut)
+        return fut
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
+        patch.object(client._loop, "create_future", capturing_create_future),
+        patch.object(client, "_wait_for_free_connection_slot") as mock_settle,
+    ):
+        task, _callback = await start_connect(bleak_client, mock_connect)
+        # Simulate the link coming up while a signal lands at the await.
+        client._is_connected = True
+        captured[0].set_exception(_Signal())
+        with pytest.raises(_Signal):
+            await task
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
+    # No settle on the signal path; only the entry gate call happened.
+    assert mock_settle.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -557,11 +654,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        mock_connect.assert_called_once()
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)
         assert client._is_connected
         # Cancel before the awaiting task resumes: the future already has a
@@ -603,11 +696,7 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        mock_connect.assert_called_once()
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 1)
         with pytest.raises(BleakError, match="while connecting"):
             await task
@@ -615,46 +704,6 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
     assert client._cancel_connection_state is None
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_error_after_link_up_logs_settle_timeout(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test a slot that never settles after a connect error is logged.
-
-    The settle after an error-after-link-up release must not mask the
-    original error, but its timeout is the direct cause of the next
-    retry's entry gate failing, so it is logged rather than dropped.
-    """
-    bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client._client, "bluetooth_device_disconnect"),
-        patch.object(
-            client,
-            "_wait_for_free_connection_slot",
-            # First call is the connect entry gate; the second is the
-            # settle after the release, which times out.
-            side_effect=[None, TimeoutError("no slot")],
-        ),
-        caplog.at_level(logging.DEBUG),
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
-        callback(True, 23, 1)
-        with pytest.raises(BleakError, match="while connecting"):
-            await task
-
-    assert "Slot did not settle after failed connect" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -684,10 +733,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
         ) as mock_disconnect,
         caplog.at_level(logging.WARNING),
     ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)
         assert task.cancel() is True
         with pytest.raises(asyncio.CancelledError):
@@ -701,71 +747,65 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
 
 
 @pytest.mark.asyncio
-async def test_bleak_client_orphan_release_skipped_when_reconnected(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test the orphan release yields to an attempt still in flight.
-
-    A late ``connected=True`` for an abandoned attempt must not release
-    the link while a newer attempt on the same client instance has a
-    connection-state subscription live; releasing by address would tear
-    that attempt down.
-    """
-    _bleak_client, client = bleak_pair
-    with patch.object(
-        client._client,
-        "bluetooth_device_disconnect_no_wait",
-    ) as mock_disconnect:
-        client._cancel_connection_state = Mock()
-        fut: asyncio.Future[bool] = client._loop.create_future()
-        fut.cancel()
-        client._on_bluetooth_connection_state(fut, True, 23, 0)
-        client._cancel_connection_state = None
-
-    mock_disconnect.assert_not_called()
-    assert not client.is_connected
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_services_failure_logs_settle_timeout(
+@pytest.mark.parametrize(
+    ("services_boom", "expected_error", "expected_log"),
+    [
+        (False, "while connecting", "failed connect"),
+        (True, "services boom", "failed connect setup"),
+    ],
+)
+async def test_bleak_client_connect_failure_logs_settle_timeout(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     caplog: pytest.LogCaptureFixture,
+    services_boom: bool,
+    expected_error: str,
+    expected_log: str,
 ) -> None:
     """
-    Test a slot that never settles after a setup failure is logged.
+    Test a slot that never settles after a failed attempt is logged.
 
-    The settle wait after a failed pair/services step must not mask the
-    original error, but its timeout is the direct cause of the next
-    retry's entry gate failing, so it is logged rather than dropped.
+    Covers both failure shapes that settle before the retry: a connect
+    error after the link came up and a service discovery failure. The
+    settle timeout must not mask the original error, but it is the
+    direct cause of the next retry's entry gate failing, so it is
+    logged rather than dropped.
     """
     bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client, "_get_services", side_effect=BleakError("services boom")),
-        patch.object(client._client, "bluetooth_device_disconnect"),
-        patch.object(
-            client,
-            "_wait_for_free_connection_slot",
-            # First call is the connect entry gate; the second is the
-            # settle after the release, which times out.
-            side_effect=[None, TimeoutError("no slot")],
-        ),
-        caplog.at_level(logging.DEBUG),
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
-        callback(True, 23, 0)
-        with pytest.raises(BleakError, match="services boom"):
+
+    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+        raise BleakError("services boom")
+
+    with contextlib.ExitStack() as stack:
+        mock_connect = stack.enter_context(
+            patch.object(
+                client._client,
+                "bluetooth_device_connect",
+                return_value=Mock(),
+            )
+        )
+        stack.enter_context(
+            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
+        )
+        stack.enter_context(
+            patch.object(
+                client,
+                "_wait_for_free_connection_slot",
+                # First call is the connect entry gate; the second is the
+                # settle after the release, which times out.
+                side_effect=[None, TimeoutError("no slot")],
+            )
+        )
+        if services_boom:
+            stack.enter_context(
+                patch.object(client, "_get_services", side_effect=_boom_get_services)
+            )
+        stack.enter_context(caplog.at_level(logging.DEBUG))
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 0 if services_boom else 1)
+        with pytest.raises(BleakError, match=expected_error):
             await task
 
-    assert "Slot did not settle after failed connect setup" in caplog.text
+    assert f"Slot did not settle after {expected_log}" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -792,10 +832,7 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(bleak_client, mock_connect)
         # connected with an error code: stores a BleakError on the future
         # while _is_connected is already set.
         callback(True, 23, 1)
@@ -806,47 +843,6 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
 
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_late_connected_callback_does_not_resurrect(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test a late ``connected=True`` through the full ``connect()`` cancel path.
-
-    Once the attempt has been abandoned, a late connection-state callback
-    must not mark the client connected again and must release the link
-    the ESP just established. The unit-level twin in
-    ``test_client_branches.py`` drives the callback directly and also
-    guards the MTU cache.
-    """
-    bleak_client, client = bleak_pair
-    mock_cancel_connection_state = Mock()
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=mock_cancel_connection_state,
-        ) as mock_connect,
-        patch.object(
-            client._client,
-            "bluetooth_device_disconnect_no_wait",
-        ) as mock_disconnect,
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
-        assert task.cancel() is True
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        callback(True, 23, 0)
-        assert not client.is_connected
-        assert client._async_esp_disconnected not in client._disconnect_callbacks
-
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
 
 
 @pytest.mark.asyncio
@@ -882,12 +878,12 @@ async def test_bleak_client_connect_raises_after_connected_future_resolved(
     """
     Test ``bluetooth_device_connect`` raising after the callback fires.
 
-    Exercises the ``if connected_future.done():`` branch inside the
+    Exercises the ``if connected_future.done():`` arm inside the
     ``except Exception`` handler around the ``bluetooth_device_connect``
     call. The callback reports a failed connection (which sets a
     ``BleakError`` on ``connected_future``), then ``bluetooth_device_connect``
-    itself raises. The already-resolved future must be drained (with the
-    BleakError suppressed) and the original exception must propagate.
+    itself raises. The stored error is retrieved via
+    ``_retrieve_future_error`` and the original exception propagates.
     """
     bleak_client, client = bleak_pair
 
@@ -913,19 +909,16 @@ async def test_bleak_client_connect_raises_after_connected_future_resolved(
 
 
 @pytest.mark.asyncio
-async def test_bleak_client_connect_inner_cancelled_drains_resolved_future(
+async def test_bleak_client_connect_inner_cancelled_retrieves_resolved_future_error(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """
-    Test inner CancelledError after the callback fires drains the future.
+    Test the inner cancel handler retrieves an already-stored error.
 
-    Exercises the ``if connected_future.done():`` branch inside the
-    ``except asyncio.CancelledError`` handler around the
-    ``bluetooth_device_connect`` call. The callback resolves
-    ``connected_future`` with a ``BleakError`` (failed connection), then
-    ``bluetooth_device_connect`` raises ``CancelledError``. The
-    already-resolved future must be drained (BleakError suppressed) before
-    the CancelledError is converted to a ``BleakError`` for the caller.
+    If ``bluetooth_device_connect`` raises ``CancelledError`` after the
+    connection-state callback already resolved ``connected_future`` with
+    an error, ``_retrieve_future_error`` marks it retrieved so asyncio
+    does not warn about it, and the cancellation handling proceeds.
     """
     bleak_client, client = bleak_pair
 
@@ -955,13 +948,10 @@ async def test_bleak_client_connect_outer_cancel_without_subscription(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """
-    Test outer cancel skips cleanup when no cancel handle was returned.
+    Test outer cancellation before the subscription handle was stored.
 
-    Exercises the ``if cancel_connection_state is not None`` guard inside
-    the outer ``await connected_future`` cancellation handler. When
-    ``bluetooth_device_connect`` returns ``None`` (no subscription handle),
-    ``self._cancel_connection_state`` stays ``None``; a real cancel of the
-    awaiting task must not attempt to call a missing cancel callable.
+    The cleanup path funnels through ``_async_disconnected_cleanup``,
+    which tolerates ``_cancel_connection_state`` still being ``None``.
     """
     bleak_client, client = bleak_pair
 
@@ -1054,10 +1044,7 @@ async def test_bleak_client_connect_get_services_cancel_releases_link(
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
+        task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)
         await in_get_services.wait()
         assert task.cancel() is True

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -19,6 +19,7 @@ from bleak.exc import BleakError
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
+    DISCONNECT_TIMEOUT,
     GATT_HEADER_SIZE,
     ESPHomeClient,
     ESPHomeClientData,
@@ -570,7 +571,9 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_disconnect.assert_called_once_with(
+        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+    )
     assert not client.is_connected
     mock_cancel_connection_state.assert_called_once_with()
     assert client._cancel_connection_state is None
@@ -610,7 +613,9 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
         with pytest.raises(BleakError, match="while connecting"):
             await task
 
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_disconnect.assert_called_once_with(
+        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+    )
     assert not client.is_connected
     assert client._cancel_connection_state is None
 
@@ -652,10 +657,129 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_disconnect.assert_called_once_with(
+        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+    )
     assert not client.is_connected
     assert "Failed to release ESP-side connection" in caplog.text
     assert "boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_shielded_disconnect_returns_when_inner_task_is_cancelled(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test the shielded release terminates when its inner task is cancelled.
+
+    Loop teardown cancels every pending task, including the inner
+    disconnect task. A shield on a done task returns it directly and
+    awaiting a cancelled task raises without yielding, so the drain must
+    exit on the inner task's state rather than loop on the awaits; it must
+    also not report an inner cancel as an absorbed caller cancellation,
+    and must warn that the slot may stay allocated.
+    """
+    _bleak_client, client = bleak_pair
+    in_disconnect = asyncio.Event()
+
+    async def _hang_disconnect() -> None:
+        in_disconnect.set()
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(client, "_disconnect_no_wait", side_effect=_hang_disconnect),
+        caplog.at_level(logging.WARNING),
+    ):
+        release_task = asyncio.create_task(client._shielded_disconnect())
+        await in_disconnect.wait()
+        # Cancel the inner disconnect task, not the release wrapper.
+        inner_tasks = [
+            t
+            for t in asyncio.all_tasks()
+            if t is not release_task and t is not asyncio.current_task()
+        ]
+        assert len(inner_tasks) == 1
+        inner_tasks[0].cancel()
+        # Bounded wait proves the drain does not spin forever.
+        absorbed = await asyncio.wait_for(release_task, timeout=2)
+
+    assert absorbed is False
+    assert "release was cancelled before it completed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_orphan_release_failure_is_warned(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test an orphan release that raises surfaces as a warning.
+
+    Nothing else observes the fire-and-forget release; an exception that
+    escapes it must be retrieved and logged, not left for asyncio's
+    ``Task exception was never retrieved``.
+    """
+    _bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client,
+            "_shielded_disconnect",
+            side_effect=RuntimeError("release boom"),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        fut: asyncio.Future[bool] = client._loop.create_future()
+        fut.cancel()
+        client._on_bluetooth_connection_state(fut, True, 23, 0)
+        orphan_task = next(iter(client._orphan_disconnect_tasks))
+        with pytest.raises(RuntimeError, match="release boom"):
+            await orphan_task
+
+    assert not client._orphan_disconnect_tasks
+    assert "release failed" in caplog.text
+    assert "release boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_services_failure_logs_settle_timeout(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test a slot that never settles after a setup failure is logged.
+
+    The settle wait after a failed pair/services step must not mask the
+    original error, but its timeout is the direct cause of the next
+    retry's entry gate failing, so it is logged rather than dropped.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_get_services", side_effect=BleakError("services boom")),
+        patch.object(client._client, "bluetooth_device_disconnect"),
+        patch.object(
+            client,
+            "_wait_for_free_connection_slot",
+            # First call is the connect entry gate; the second is the
+            # settle after the release, which times out.
+            side_effect=[None, TimeoutError("no slot")],
+        ),
+        caplog.at_level(logging.DEBUG),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        with pytest.raises(BleakError, match="services boom"):
+            await task
+
+    assert "Slot did not settle after failed connect setup" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -690,7 +814,7 @@ async def test_bleak_client_orphan_release_cancelled_is_warned(
             await orphan_task
 
     assert not client._orphan_disconnect_tasks
-    assert "release was cancelled before it completed" in caplog.text
+    assert "release was cancelled before it started" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -729,7 +853,9 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_disconnect.assert_called_once_with(
+        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+    )
     assert not client.is_connected
 
 
@@ -920,7 +1046,9 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         assert client._orphan_disconnect_tasks
         await next(iter(client._orphan_disconnect_tasks))
 
-    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_disconnect.assert_called_once_with(
+        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -675,15 +675,22 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
     Once the connect attempt has been abandoned (future done, cleanup ran),
     a late connection-state callback must not mark the client connected
     again; nobody owns the client anymore and the state would never be
-    corrected.
+    corrected. The ESP did just establish the link though, so the client
+    must release it rather than leave it pinning a proxy slot.
     """
     bleak_client, client = bleak_pair
     mock_cancel_connection_state = Mock()
-    with patch.object(
-        client._client,
-        "bluetooth_device_connect",
-        return_value=mock_cancel_connection_state,
-    ) as mock_connect:
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=mock_cancel_connection_state,
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+        ) as mock_disconnect,
+    ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -692,9 +699,15 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         with pytest.raises(asyncio.CancelledError):
             await task
 
-    callback(True, 23, 0)
+        callback(True, 23, 0)
+        assert not client.is_connected
+        assert client._async_esp_disconnected not in client._disconnect_callbacks
+        # Drain the orphan-release task spawned by the late callback.
+        assert client._orphan_disconnect_task is not None
+        await client._orphan_disconnect_task
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
-    assert client._async_esp_disconnected not in client._disconnect_callbacks
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -739,6 +739,56 @@ async def test_bleak_client_connect_error_then_cancel_during_release(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_services_failure_then_cancel_during_release(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a cancel absorbed during the services-failure release still wins.
+
+    When ``_get_services`` fails after the link came up and a cancellation
+    arrives while the shielded cleanup release is in flight, the release
+    runs to completion and the cancellation outranks the original error.
+    """
+    bleak_client, client = bleak_pair
+    in_disconnect = asyncio.Event()
+    release_disconnect = asyncio.Event()
+    disconnect_finished = asyncio.Event()
+
+    async def _slow_disconnect() -> None:
+        in_disconnect.set()
+        await release_disconnect.wait()
+        disconnect_finished.set()
+
+    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+        raise BleakError("services boom")
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_get_services", side_effect=_boom_get_services),
+        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        await in_disconnect.wait()
+        assert task.cancel() is True
+        await asyncio.sleep(0)
+        release_disconnect.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+        # The release ran to completion; the patched _disconnect_no_wait
+        # stands in for the real one, which also clears the client state.
+        assert disconnect_finished.is_set()
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -545,6 +545,41 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_settle_runs_with_scanning_resumed(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test the settle runs outside the scanner's connecting pause.
+
+    The release is already sent by then, so a saturated proxy must not
+    have its scanner blanked for up to the settle timeout as well.
+    """
+    bleak_client, client = bleak_pair
+    scanning_during_settle: list[bool] = []
+
+    async def _record_scanning(context: str) -> None:
+        scanning_during_settle.append(client._scanner.scanning)
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
+        patch.object(
+            client, "_settle_slot_after_failure", side_effect=_record_scanning
+        ),
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    assert scanning_during_settle == [True]
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_failed_release_skips_settle(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     caplog: pytest.LogCaptureFixture,
@@ -655,9 +690,11 @@ async def test_bleak_client_connect_services_drop_skips_settle(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failure_shape", ["error_code", "pair", "services"])
 async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
+    failure_shape: str,
 ) -> None:
     """
     Test abandonment is silent to the consumer and the callback survives.
@@ -665,31 +702,68 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     An abandoned attempt never handed the consumer a connected client, so
     it must not fire ``disconnected_callback`` and must not null it; the
     retry connector reuses one client instance, and a later successful
-    connect still has to deliver the real disconnect notification.
+    connect still has to deliver the real disconnect notification. Pinned
+    for every abandonment shape: a connect error after link up, a failed
+    pairing, and a failed service discovery.
     """
     bleak_client, client = bleak_pair
     disconnected_callback = Mock()
     client._disconnected_callback = disconnected_callback
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
-        patch.object(
-            client._client,
-            "bluetooth_gatt_get_services",
-            return_value=esphome_bluetooth_gatt_services,
-        ),
-    ):
-        # Attempt 1 fails after the link came up.
-        task, callback = await start_connect(bleak_client, mock_connect)
-        callback(True, 23, 1)
-        with pytest.raises(BleakError, match="while connecting"):
-            await task
-        disconnected_callback.assert_not_called()
-        assert client._disconnected_callback is disconnected_callback
+
+    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+        raise BleakError("services boom")
+
+    with contextlib.ExitStack() as stack:
+        mock_connect = stack.enter_context(
+            patch.object(
+                client._client,
+                "bluetooth_device_connect",
+                return_value=Mock(),
+            )
+        )
+        stack.enter_context(
+            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
+        )
+        stack.enter_context(
+            patch.object(
+                client._client,
+                "bluetooth_gatt_get_services",
+                return_value=esphome_bluetooth_gatt_services,
+            )
+        )
+        # The failure injections live in their own scope so attempt 2
+        # runs without them.
+        with contextlib.ExitStack() as failure_stack:
+            pair = False
+            if failure_shape == "pair":
+                pair = True
+                failure_stack.enter_context(
+                    patch.object(
+                        client._client,
+                        "bluetooth_device_pair",
+                        return_value=BluetoothDevicePairing(
+                            address=client._address_as_int, paired=False, error=1
+                        ),
+                    )
+                )
+            if failure_shape == "services":
+                failure_stack.enter_context(
+                    patch.object(
+                        client, "_get_services", side_effect=_boom_get_services
+                    )
+                )
+            # Attempt 1 fails; the consumer never saw a connected client.
+            task = asyncio.create_task(
+                client.connect(pair=pair, dangerous_use_bleak_cache=True)
+            )
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            callback = mock_connect.call_args_list[-1][0][1]
+            callback(True, 23, 1 if failure_shape == "error_code" else 0)
+            with pytest.raises(BleakError):
+                await task
+            disconnected_callback.assert_not_called()
+            assert client._disconnected_callback is disconnected_callback
 
         # Attempt 2 succeeds on the same instance.
         task, callback = await start_connect(bleak_client, mock_connect)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -342,7 +342,9 @@ async def test_bleak_client_connect(
     ) as mock_disconnect:
         await client.disconnect()
 
-    mock_disconnect.assert_called_once()
+    # The public path keeps aioesphomeapi's default timeout; only the
+    # shielded cleanup paths pass an explicit short one.
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
 
 
 @pytest.mark.asyncio
@@ -621,6 +623,46 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_error_after_link_up_logs_settle_timeout(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test a slot that never settles after a connect error is logged.
+
+    The settle after an error-after-link-up release must not mask the
+    original error, but its timeout is the direct cause of the next
+    retry's entry gate failing, so it is logged rather than dropped.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client._client, "bluetooth_device_disconnect"),
+        patch.object(
+            client,
+            "_wait_for_free_connection_slot",
+            # First call is the connect entry gate; the second is the
+            # settle after the release, which times out.
+            side_effect=[None, TimeoutError("no slot")],
+        ),
+        caplog.at_level(logging.DEBUG),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    assert "Slot did not settle after failed connect" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logged(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     caplog: pytest.LogCaptureFixture,
@@ -732,8 +774,18 @@ async def test_bleak_client_orphan_release_skipped_when_reconnected(
         client._is_connected = True
         assert await orphan_task is False
 
+        # The guard also yields to an attempt still in flight, marked by
+        # a live connection-state subscription.
+        client._is_connected = False
+        client._cancel_connection_state = Mock()
+        fut2: asyncio.Future[bool] = client._loop.create_future()
+        fut2.cancel()
+        client._on_bluetooth_connection_state(fut2, True, 23, 0)
+        orphan_task = next(iter(client._orphan_disconnect_tasks))
+        assert await orphan_task is False
+        client._cancel_connection_state = None
+
     mock_disconnect.assert_not_called()
-    assert client.is_connected
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -528,6 +528,176 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test cancellation delivered after the link already came up.
+
+    If the awaiting task is cancelled after the connection-state callback
+    reported ``connected=True`` (asyncio still delivers ``CancelledError``
+    at the ``await`` even though the future holds a result), the ESP side
+    holds a live connection that no client owns. ``connect()`` must release
+    it with ``bluetooth_device_disconnect`` so the proxy's slot is not
+    leaked, clean up local state, and still propagate the cancellation.
+    """
+    bleak_client, client = bleak_pair
+    mock_cancel_connection_state = Mock()
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=mock_cancel_connection_state,
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+        ) as mock_disconnect,
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        mock_connect.assert_called_once()
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        assert client._is_connected
+        # Cancel before the awaiting task resumes: the future already has a
+        # result, but Task._must_cancel still raises CancelledError at the
+        # await point.
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
+    mock_cancel_connection_state.assert_called_once_with()
+    assert client._cancel_connection_state is None
+    assert client._async_esp_disconnected not in client._disconnect_callbacks
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a ``connected=True`` state with an error code releases the link.
+
+    When the connection-state callback reports connected with an error,
+    the future fails while ``_is_connected`` is already set; the ESP side
+    may hold a live connection, so ``connect()`` must release it instead
+    of leaking the proxy's slot.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+        ) as mock_disconnect,
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        mock_connect.assert_called_once()
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
+    assert client._cancel_connection_state is None
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test the cancel-after-link-up disconnect survives a re-cancellation.
+
+    The release of the ESP-side connection is shielded; a second
+    cancellation arriving while it is in flight must not interrupt it
+    half-way. The disconnect must run to completion and the original
+    cancellation must still propagate.
+    """
+    bleak_client, client = bleak_pair
+    in_disconnect = asyncio.Event()
+    release_disconnect = asyncio.Event()
+    disconnect_finished = asyncio.Event()
+
+    async def _slow_disconnect() -> bool:
+        in_disconnect.set()
+        await release_disconnect.wait()
+        disconnect_finished.set()
+        return True
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_disconnect", side_effect=_slow_disconnect),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        mock_connect.assert_called_once()
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        assert task.cancel() is True
+        await in_disconnect.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        release_disconnect.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+        assert disconnect_finished.is_set()
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_late_connected_callback_does_not_resurrect(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a late ``connected=True`` after a cancelled connect is ignored.
+
+    Once the connect attempt has been abandoned (future done, cleanup ran),
+    a late connection-state callback must not mark the client connected
+    again; nobody owns the client anymore and the state would never be
+    corrected.
+    """
+    bleak_client, client = bleak_pair
+    mock_cancel_connection_state = Mock()
+    with patch.object(
+        client._client,
+        "bluetooth_device_connect",
+        return_value=mock_cancel_connection_state,
+    ) as mock_connect:
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    callback(True, 23, 0)
+    assert not client.is_connected
+    assert client._async_esp_disconnected not in client._disconnect_callbacks
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_raises_when_device_connect_raises(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1176,6 +1176,73 @@ async def test_bleak_client_connect_rpc_signal_cleans_up(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_await_signal_makes_future_terminal(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a signal delivered at the future await cancels the future.
+
+    A pending future left behind would let a late ``connected=True``
+    take the success path and resurrect the abandoned client with no
+    release, leaking the proxy slot.
+    """
+    _bleak_client, client = bleak_pair
+    with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
+        coro = client.connect(pair=False, dangerous_use_bleak_cache=True)
+        # Drive manually so the signal lands at the await itself, with
+        # the future still pending.
+        coro.send(None)
+        with pytest.raises(_Signal):
+            coro.throw(_Signal())
+        callback = mock_connect.call_args_list[-1][0][1]
+        callback(True, 23, 0)
+    assert not client.is_connected
+    assert client._async_esp_disconnected not in client._disconnect_callbacks
+    # The late link up is released as an orphan, not resurrected.
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_await_signal_retrieves_stored_error(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A signal racing a stored future error retrieves the error."""
+    _bleak_client, client = bleak_pair
+    with patch_connect_rpcs(client) as (mock_connect, _mock_disconnect):
+        coro = client.connect(pair=False, dangerous_use_bleak_cache=True)
+        coro.send(None)
+        callback = mock_connect.call_args_list[-1][0][1]
+        # Fail the future, then deliver the signal before the coroutine
+        # resumes.
+        callback(False, 23, 1)
+        with (
+            caplog.at_level(logging.DEBUG),
+            pytest.raises(_Signal),
+        ):
+            coro.throw(_Signal())
+    assert not client.is_connected
+    assert "Discarding stored connect error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_normalize_connect_future_branches(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """The helper cancels a pending future and retrieves a done one."""
+    _bleak_client, client = bleak_pair
+    loop = asyncio.get_running_loop()
+    pending: asyncio.Future[bool] = loop.create_future()
+    client._normalize_connect_future(pending, "boom")
+    assert pending.cancelled()
+    done: asyncio.Future[bool] = loop.create_future()
+    done.set_exception(BleakError("stored"))
+    client._normalize_connect_future(done)
+    # Retrieved, so asyncio does not warn at GC time.
+    assert done.exception() is not None
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_outer_base_exception_cleans_up(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -20,7 +20,6 @@ from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
     GATT_HEADER_SIZE,
-    SHIELDED_DISCONNECT_TIMEOUT,
     ESPHomeClient,
     ESPHomeClientData,
 )
@@ -342,8 +341,8 @@ async def test_bleak_client_connect(
     ) as mock_disconnect:
         await client.disconnect()
 
-    # The public path keeps aioesphomeapi's default timeout; only the
-    # shielded cleanup paths pass an explicit short one.
+    # The public path awaits the confirmation with aioesphomeapi's
+    # default timeout; cleanup paths use the synchronous no-wait helper.
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
 
 
@@ -542,7 +541,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
     reported ``connected=True`` (asyncio still delivers ``CancelledError``
     at the ``await`` even though the future holds a result), the ESP side
     holds a live connection that no client owns. ``connect()`` must release
-    it with ``bluetooth_device_disconnect`` so the proxy's slot is not
+    it with the synchronous no-wait disconnect so the proxy's slot is not
     leaked, clean up local state, and still propagate the cancellation.
     """
     bleak_client, client = bleak_pair
@@ -555,7 +554,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
         ) as mock_connect,
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
@@ -573,9 +572,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
     mock_cancel_connection_state.assert_called_once_with()
     assert client._cancel_connection_state is None
@@ -603,7 +600,7 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
         ) as mock_connect,
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
@@ -615,9 +612,7 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
         with pytest.raises(BleakError, match="while connecting"):
             await task
 
-    mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
     assert client._cancel_connection_state is None
 
@@ -684,7 +679,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
         ) as mock_connect,
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
             side_effect=APIConnectionError("boom"),
         ) as mock_disconnect,
         caplog.at_level(logging.WARNING),
@@ -699,55 +694,10 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
     assert "Failed to release ESP-side connection" in caplog.text
     assert "boom" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_shielded_disconnect_returns_when_inner_task_is_cancelled(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test the shielded release terminates when its inner task is cancelled.
-
-    Loop teardown cancels every pending task, including the inner
-    disconnect task. A shield on a done task returns it directly and
-    awaiting a cancelled task raises without yielding, so the drain must
-    exit on the inner task's state rather than loop on the awaits; it must
-    also not report an inner cancel as an absorbed caller cancellation,
-    and must warn that the slot may stay allocated.
-    """
-    _bleak_client, client = bleak_pair
-    in_disconnect = asyncio.Event()
-    inner_task: list[asyncio.Task[None]] = []
-
-    async def _hang_disconnect(*args: Any) -> None:
-        # Capture the inner disconnect task so the test can cancel it
-        # directly instead of scanning asyncio.all_tasks().
-        task = asyncio.current_task()
-        assert task is not None
-        inner_task.append(task)
-        in_disconnect.set()
-        await asyncio.Event().wait()
-
-    with (
-        patch.object(client, "_disconnect_no_wait", side_effect=_hang_disconnect),
-        caplog.at_level(logging.WARNING),
-    ):
-        release_task = asyncio.create_task(client._shielded_disconnect())
-        await in_disconnect.wait()
-        # Cancel the inner disconnect task, not the release wrapper.
-        inner_task[0].cancel()
-        # Bounded wait proves the drain does not spin forever.
-        absorbed = await asyncio.wait_for(release_task, timeout=2)
-
-    assert absorbed is False
-    assert "release was cancelled before it completed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -755,70 +705,26 @@ async def test_bleak_client_orphan_release_skipped_when_reconnected(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """
-    Test a scheduled orphan release yields to a newer live link.
+    Test the orphan release yields to an attempt still in flight.
 
-    If a new connect on the same client instance establishes a link for
-    the address before the scheduled release runs, the release must not
-    tear that link down.
+    A late ``connected=True`` for an abandoned attempt must not release
+    the link while a newer attempt on the same client instance has a
+    connection-state subscription live; releasing by address would tear
+    that attempt down.
     """
     _bleak_client, client = bleak_pair
     with patch.object(
         client._client,
-        "bluetooth_device_disconnect",
+        "bluetooth_device_disconnect_no_wait",
     ) as mock_disconnect:
+        client._cancel_connection_state = Mock()
         fut: asyncio.Future[bool] = client._loop.create_future()
         fut.cancel()
         client._on_bluetooth_connection_state(fut, True, 23, 0)
-        orphan_task = next(iter(client._orphan_disconnect_tasks))
-        # A newer connect wins the race before the release task runs.
-        client._is_connected = True
-        assert await orphan_task is False
-
-        # The guard also yields to an attempt still in flight, marked by
-        # a live connection-state subscription.
-        client._is_connected = False
-        client._cancel_connection_state = Mock()
-        fut2: asyncio.Future[bool] = client._loop.create_future()
-        fut2.cancel()
-        client._on_bluetooth_connection_state(fut2, True, 23, 0)
-        orphan_task = next(iter(client._orphan_disconnect_tasks))
-        assert await orphan_task is False
         client._cancel_connection_state = None
 
     mock_disconnect.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_orphan_release_failure_is_warned(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test an orphan release that raises surfaces as a warning.
-
-    Nothing else observes the fire-and-forget release; an exception that
-    escapes it must be retrieved and logged, not left for asyncio's
-    ``Task exception was never retrieved``.
-    """
-    _bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client,
-            "_shielded_disconnect",
-            side_effect=RuntimeError("release boom"),
-        ),
-        caplog.at_level(logging.WARNING),
-    ):
-        fut: asyncio.Future[bool] = client._loop.create_future()
-        fut.cancel()
-        client._on_bluetooth_connection_state(fut, True, 23, 0)
-        orphan_task = next(iter(client._orphan_disconnect_tasks))
-        with pytest.raises(RuntimeError, match="release boom"):
-            await orphan_task
-
-    assert not client._orphan_disconnect_tasks
-    assert "release failed" in caplog.text
-    assert "release boom" in caplog.text
+    assert not client.is_connected
 
 
 @pytest.mark.asyncio
@@ -863,41 +769,6 @@ async def test_bleak_client_connect_services_failure_logs_settle_timeout(
 
 
 @pytest.mark.asyncio
-async def test_bleak_client_orphan_release_cancelled_is_warned(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    Test a cancelled orphan release surfaces as a warning.
-
-    The orphan release is fire-and-forget; nothing else observes it, so
-    if it never completes (loop teardown mid-flight) the ESP link may
-    still be up and that must be visible in the logs.
-    """
-    _bleak_client, client = bleak_pair
-    with (
-        patch.object(
-            client,
-            "_shielded_disconnect",
-            side_effect=asyncio.CancelledError,
-        ),
-        caplog.at_level(logging.WARNING),
-    ):
-        fut: asyncio.Future[bool] = client._loop.create_future()
-        fut.cancel()
-        # Late connected=True for an abandoned attempt spawns the orphan
-        # release, which here ends cancelled before it can complete.
-        client._on_bluetooth_connection_state(fut, True, 23, 0)
-        assert client._orphan_disconnect_tasks
-        orphan_task = next(iter(client._orphan_disconnect_tasks))
-        with pytest.raises(asyncio.CancelledError):
-            await orphan_task
-
-    assert not client._orphan_disconnect_tasks
-    assert "release was cancelled before it started" in caplog.text
-
-
-@pytest.mark.asyncio
 async def test_bleak_client_connect_cancel_after_error_retrieves_future(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
@@ -918,7 +789,7 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
         ) as mock_connect,
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
@@ -933,155 +804,7 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
             await task
         assert task.cancelled()
 
-    mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
-    assert not client.is_connected
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_error_then_cancel_during_release(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test a cancel absorbed during the error-path release still wins.
-
-    When the connect fails after the link came up and a cancellation
-    arrives while the shielded release is in flight, the release runs to
-    completion and the cancellation outranks the original error.
-    """
-    bleak_client, client = bleak_pair
-    in_disconnect = asyncio.Event()
-    release_disconnect = asyncio.Event()
-    disconnect_finished = asyncio.Event()
-
-    async def _slow_disconnect(*args: Any) -> None:
-        in_disconnect.set()
-        await release_disconnect.wait()
-        disconnect_finished.set()
-
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
-        callback(True, 23, 1)
-        await in_disconnect.wait()
-        assert task.cancel() is True
-        await asyncio.sleep(0)
-        release_disconnect.set()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        assert task.cancelled()
-        assert disconnect_finished.is_set()
-
-    assert not client.is_connected
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_services_failure_then_cancel_during_release(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test a cancel absorbed during the services-failure release still wins.
-
-    When ``_get_services`` fails after the link came up and a cancellation
-    arrives while the shielded cleanup release is in flight, the release
-    runs to completion and the cancellation outranks the original error.
-    """
-    bleak_client, client = bleak_pair
-    in_disconnect = asyncio.Event()
-    release_disconnect = asyncio.Event()
-    disconnect_finished = asyncio.Event()
-
-    async def _slow_disconnect(*args: Any) -> None:
-        in_disconnect.set()
-        await release_disconnect.wait()
-        disconnect_finished.set()
-
-    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
-        raise BleakError("services boom")
-
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client, "_get_services", side_effect=_boom_get_services),
-        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        callback = mock_connect.call_args_list[0][0][1]
-        callback(True, 23, 0)
-        await in_disconnect.wait()
-        assert task.cancel() is True
-        await asyncio.sleep(0)
-        release_disconnect.set()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        assert task.cancelled()
-        # The release ran to completion; the patched _disconnect_no_wait
-        # stands in for the real one, which also clears the client state.
-        assert disconnect_finished.is_set()
-
-
-@pytest.mark.asyncio
-async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-) -> None:
-    """
-    Test the cancel-after-link-up disconnect survives a re-cancellation.
-
-    The release of the ESP-side connection is shielded; a second
-    cancellation arriving while it is in flight must not interrupt it
-    half-way. The disconnect must run to completion and the original
-    cancellation must still propagate.
-    """
-    bleak_client, client = bleak_pair
-    in_disconnect = asyncio.Event()
-    release_disconnect = asyncio.Event()
-    disconnect_finished = asyncio.Event()
-
-    async def _slow_disconnect(*args: Any) -> None:
-        in_disconnect.set()
-        await release_disconnect.wait()
-        disconnect_finished.set()
-
-    with (
-        patch.object(
-            client._client,
-            "bluetooth_device_connect",
-            return_value=Mock(),
-        ) as mock_connect,
-        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
-    ):
-        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        mock_connect.assert_called_once()
-        callback = mock_connect.call_args_list[0][0][1]
-        callback(True, 23, 0)
-        assert task.cancel() is True
-        await in_disconnect.wait()
-        task.cancel()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        release_disconnect.set()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        assert task.cancelled()
-        assert disconnect_finished.is_set()
-
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
 
 
@@ -1108,7 +831,7 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         ) as mock_connect,
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
@@ -1122,13 +845,8 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         callback(True, 23, 0)
         assert not client.is_connected
         assert client._async_esp_disconnected not in client._disconnect_callbacks
-        # Drain the orphan-release task spawned by the late callback.
-        assert client._orphan_disconnect_tasks
-        await next(iter(client._orphan_disconnect_tasks))
 
-    mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
 
 
 @pytest.mark.asyncio
@@ -1308,40 +1026,21 @@ async def test_bleak_client_connect_outer_base_exception_cleans_up(
 
 
 @pytest.mark.asyncio
-async def test_bleak_client_connect_get_services_cleanup_shielded(
+async def test_bleak_client_connect_get_services_cancel_releases_link(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """
-    Test the disconnect cleanup is shielded against re-cancellation.
+    Test a cancel during service discovery releases the ESP-side link.
 
-    When ``_get_services`` raises ``CancelledError`` the connect path
-    runs ``await self._disconnect()`` to release the BLE connection on
-    the ESP side. ``_disconnect`` is itself a cancellation point, so a
-    parent-task cancellation arriving while it is running would
-    interrupt it half-way and leave the device connected on the ESP
-    side. The fix wraps the disconnect in ``asyncio.shield`` and, on
-    re-cancellation, finishes awaiting the disconnect before re-raising
-    so the cleanup completes and the original cancellation still
-    propagates to the caller.
-
-    This test asserts both that ``CancelledError`` propagates and that
-    the slow ``_disconnect`` ran to completion (its
-    ``disconnect_finished`` event is set).
+    The release is synchronous, so the cancellation is neither delayed
+    nor absorbed; it propagates immediately after the release is sent.
     """
     bleak_client, client = bleak_pair
-    in_disconnect = asyncio.Event()
-    release_disconnect = asyncio.Event()
-    disconnect_finished = asyncio.Event()
     in_get_services = asyncio.Event()
 
     async def _hang_get_services(*args: Any, **kwargs: Any) -> Any:
         in_get_services.set()
         await asyncio.Event().wait()
-
-    async def _slow_disconnect(*args: Any) -> None:
-        in_disconnect.set()
-        await release_disconnect.wait()
-        disconnect_finished.set()
 
     with (
         patch.object(
@@ -1350,25 +1049,24 @@ async def test_bleak_client_connect_get_services_cleanup_shielded(
             return_value=Mock(),
         ) as mock_connect,
         patch.object(client, "_get_services", side_effect=_hang_get_services),
-        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        mock_connect.assert_called_once()
         callback = mock_connect.call_args_list[0][0][1]
         callback(True, 23, 0)
         await in_get_services.wait()
         assert task.cancel() is True
-        await in_disconnect.wait()
-        task.cancel()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        release_disconnect.set()
         with pytest.raises(asyncio.CancelledError):
             await task
         assert task.cancelled()
-        assert disconnect_finished.is_set()
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
 
 
 @pytest.mark.asyncio
@@ -1448,7 +1146,7 @@ async def test_bleak_client_connect_pair_failure_releases_slot(
         ),
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
+            "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
     ):
         task = asyncio.create_task(

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -545,6 +545,76 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_failed_release_skips_settle(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test a failed release send skips the settle.
+
+    If the disconnect request never went out (a dead API connection above
+    all), the free count can never update over that same connection;
+    settling would stall the full timeout with scanning paused.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+            side_effect=APIConnectionError("api gone"),
+        ),
+        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+        caplog.at_level(logging.DEBUG),
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    mock_settle.assert_not_awaited()
+    assert "ESP-side release skipped" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_settle_defect_logged_as_warning(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test an unexpected settle error surfaces as a warning.
+
+    A TimeoutError is the expected slow proxy shape and stays at debug;
+    anything else is a defect in the wait path and must not hide there.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
+        patch.object(
+            client,
+            "_wait_for_free_connection_slot",
+            side_effect=[None, RuntimeError("wait path defect")],
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+
+    assert "Unexpected error while waiting for the slot to settle" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_services_drop_skips_settle(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1137,29 +1137,42 @@ async def test_bleak_client_connect_outer_cancel_without_subscription(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("resolved", [False, True])
 async def test_bleak_client_connect_rpc_signal_cleans_up(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+    resolved: bool,
 ) -> None:
     """
     Test a signal raised by the connect RPC itself still tears down.
 
     aioesphomeapi releases the ESP side in its own failure handlers; the
     local abandonment must still run so the subscription and state do
-    not leak.
+    not leak, and a future the state callback already failed must be
+    retrieved so asyncio does not warn at GC time.
     """
     bleak_client, client = bleak_pair
+
+    def _maybe_resolve_then_signal(*args: Any, **kwargs: Any) -> Any:
+        if resolved:
+            # Fail the connect future via the state callback first.
+            args[1](False, 23, 1)
+        raise _Signal
+
     with (
         patch.object(
             client._client,
             "bluetooth_device_connect",
-            side_effect=_Signal,
+            side_effect=_maybe_resolve_then_signal,
         ),
+        caplog.at_level(logging.DEBUG),
         pytest.raises(_Signal),
     ):
         await bleak_client.connect(dangerous_use_bleak_cache=True)
 
     assert not client.is_connected
     assert client._cancel_connection_state is None
+    assert ("Discarding stored connect error" in caplog.text) is resolved
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -545,6 +545,94 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_services_drop_skips_settle(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a link dropped during discovery releases nothing and skips settle.
+
+    When the device disconnects mid ``_get_services`` the local state is
+    already torn down; the attempt no longer holds a slot, so there is
+    nothing to release and nothing to settle for.
+    """
+    bleak_client, client = bleak_pair
+
+    async def _drop_then_boom(*args: Any, **kwargs: Any) -> Any:
+        client._async_ble_device_disconnected()
+        raise BleakError("dropped during discovery")
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_get_services", side_effect=_drop_then_boom),
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
+        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 0)
+        with pytest.raises(BleakError, match="dropped during discovery"):
+            await task
+
+    mock_disconnect.assert_not_called()
+    mock_settle.assert_not_awaited()
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
+) -> None:
+    """
+    Test abandonment is silent to the consumer and the callback survives.
+
+    An abandoned attempt never handed the consumer a connected client, so
+    it must not fire ``disconnected_callback`` and must not null it; the
+    retry connector reuses one client instance, and a later successful
+    connect still has to deliver the real disconnect notification.
+    """
+    bleak_client, client = bleak_pair
+    disconnected_callback = Mock()
+    client._disconnected_callback = disconnected_callback
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client._client, "bluetooth_device_disconnect_no_wait"),
+        patch.object(
+            client._client,
+            "bluetooth_gatt_get_services",
+            return_value=esphome_bluetooth_gatt_services,
+        ),
+    ):
+        # Attempt 1 fails after the link came up.
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 1)
+        with pytest.raises(BleakError, match="while connecting"):
+            await task
+        disconnected_callback.assert_not_called()
+        assert client._disconnected_callback is disconnected_callback
+
+        # Attempt 2 succeeds on the same instance.
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 0)
+        await task
+        assert client.is_connected
+
+        # The real disconnect still notifies the consumer exactly once.
+        callback(False, 23, 0)
+        disconnected_callback.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_error_without_link_cleans_up_locally(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -615,6 +615,130 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logged(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a failing release does not mask the cancellation.
+
+    If the ESP-side disconnect fails while cleaning up a cancelled
+    connect, the error is logged and swallowed; the cancellation still
+    propagates to the caller.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+            side_effect=APIConnectionError("boom"),
+        ) as mock_disconnect,
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_after_error_retrieves_future(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a cancel racing a stored connect error retrieves the error.
+
+    When the connection-state callback stores a ``BleakError`` and the
+    task is cancelled before resuming, the handler must retrieve the
+    stored exception (so asyncio does not log ``Future exception was
+    never retrieved``), release the link, and propagate the cancel.
+    """
+    bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+        ) as mock_disconnect,
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        # connected with an error code: stores a BleakError on the future
+        # while _is_connected is already set.
+        callback(True, 23, 1)
+        assert task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_error_then_cancel_during_release(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a cancel absorbed during the error-path release still wins.
+
+    When the connect fails after the link came up and a cancellation
+    arrives while the shielded release is in flight, the release runs to
+    completion and the cancellation outranks the original error.
+    """
+    bleak_client, client = bleak_pair
+    in_disconnect = asyncio.Event()
+    release_disconnect = asyncio.Event()
+    disconnect_finished = asyncio.Event()
+
+    async def _slow_disconnect() -> None:
+        in_disconnect.set()
+        await release_disconnect.wait()
+        disconnect_finished.set()
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 1)
+        await in_disconnect.wait()
+        assert task.cancel() is True
+        await asyncio.sleep(0)
+        release_disconnect.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+        assert disconnect_finished.is_set()
+
+    assert not client.is_connected
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
@@ -631,11 +755,10 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
     release_disconnect = asyncio.Event()
     disconnect_finished = asyncio.Event()
 
-    async def _slow_disconnect() -> bool:
+    async def _slow_disconnect() -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()
-        return True
 
     with (
         patch.object(
@@ -643,7 +766,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
             "bluetooth_device_connect",
             return_value=Mock(),
         ) as mock_connect,
-        patch.object(client, "_disconnect", side_effect=_slow_disconnect),
+        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
@@ -670,13 +793,13 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
     """
-    Test a late ``connected=True`` after a cancelled connect is ignored.
+    Test a late ``connected=True`` through the full ``connect()`` cancel path.
 
-    Once the connect attempt has been abandoned (future done, cleanup ran),
-    a late connection-state callback must not mark the client connected
-    again; nobody owns the client anymore and the state would never be
-    corrected. The ESP did just establish the link though, so the client
-    must release it rather than leave it pinning a proxy slot.
+    Once the attempt has been abandoned, a late connection-state callback
+    must not mark the client connected again and must release the link
+    the ESP just established. The unit-level twin in
+    ``test_client_branches.py`` drives the callback directly and also
+    guards the MTU cache.
     """
     bleak_client, client = bleak_pair
     mock_cancel_connection_state = Mock()
@@ -703,11 +826,10 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         assert not client.is_connected
         assert client._async_esp_disconnected not in client._disconnect_callbacks
         # Drain the orphan-release task spawned by the late callback.
-        assert client._orphan_disconnect_task is not None
-        await client._orphan_disconnect_task
+        assert client._orphan_disconnect_tasks
+        await next(iter(client._orphan_disconnect_tasks))
 
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
-    assert not client.is_connected
 
 
 @pytest.mark.asyncio
@@ -917,11 +1039,10 @@ async def test_bleak_client_connect_get_services_cleanup_shielded(
         in_get_services.set()
         await asyncio.Event().wait()
 
-    async def _slow_disconnect() -> bool:
+    async def _slow_disconnect() -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()
-        return True
 
     with (
         patch.object(
@@ -930,7 +1051,7 @@ async def test_bleak_client_connect_get_services_cleanup_shielded(
             return_value=Mock(),
         ) as mock_connect,
         patch.object(client, "_get_services", side_effect=_hang_get_services),
-        patch.object(client, "_disconnect", side_effect=_slow_disconnect),
+        patch.object(client, "_disconnect_no_wait", side_effect=_slow_disconnect),
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -19,8 +19,8 @@ from bleak.exc import BleakError
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
-    DISCONNECT_TIMEOUT,
     GATT_HEADER_SIZE,
+    SHIELDED_DISCONNECT_TIMEOUT,
     ESPHomeClient,
     ESPHomeClientData,
 )
@@ -572,7 +572,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnects_esp(
         assert task.cancelled()
 
     mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
     assert not client.is_connected
     mock_cancel_connection_state.assert_called_once_with()
@@ -614,7 +614,7 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
             await task
 
     mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
     assert not client.is_connected
     assert client._cancel_connection_state is None
@@ -658,7 +658,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
         assert task.cancelled()
 
     mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
     assert not client.is_connected
     assert "Failed to release ESP-side connection" in caplog.text
@@ -682,8 +682,14 @@ async def test_shielded_disconnect_returns_when_inner_task_is_cancelled(
     """
     _bleak_client, client = bleak_pair
     in_disconnect = asyncio.Event()
+    inner_task: list[asyncio.Task[None]] = []
 
-    async def _hang_disconnect() -> None:
+    async def _hang_disconnect(*args: Any) -> None:
+        # Capture the inner disconnect task so the test can cancel it
+        # directly instead of scanning asyncio.all_tasks().
+        task = asyncio.current_task()
+        assert task is not None
+        inner_task.append(task)
         in_disconnect.set()
         await asyncio.Event().wait()
 
@@ -694,18 +700,40 @@ async def test_shielded_disconnect_returns_when_inner_task_is_cancelled(
         release_task = asyncio.create_task(client._shielded_disconnect())
         await in_disconnect.wait()
         # Cancel the inner disconnect task, not the release wrapper.
-        inner_tasks = [
-            t
-            for t in asyncio.all_tasks()
-            if t is not release_task and t is not asyncio.current_task()
-        ]
-        assert len(inner_tasks) == 1
-        inner_tasks[0].cancel()
+        inner_task[0].cancel()
         # Bounded wait proves the drain does not spin forever.
         absorbed = await asyncio.wait_for(release_task, timeout=2)
 
     assert absorbed is False
     assert "release was cancelled before it completed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_orphan_release_skipped_when_reconnected(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a scheduled orphan release yields to a newer live link.
+
+    If a new connect on the same client instance establishes a link for
+    the address before the scheduled release runs, the release must not
+    tear that link down.
+    """
+    _bleak_client, client = bleak_pair
+    with patch.object(
+        client._client,
+        "bluetooth_device_disconnect",
+    ) as mock_disconnect:
+        fut: asyncio.Future[bool] = client._loop.create_future()
+        fut.cancel()
+        client._on_bluetooth_connection_state(fut, True, 23, 0)
+        orphan_task = next(iter(client._orphan_disconnect_tasks))
+        # A newer connect wins the race before the release task runs.
+        client._is_connected = True
+        assert await orphan_task is False
+
+    mock_disconnect.assert_not_called()
+    assert client.is_connected
 
 
 @pytest.mark.asyncio
@@ -854,7 +882,7 @@ async def test_bleak_client_connect_cancel_after_error_retrieves_future(
         assert task.cancelled()
 
     mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
     assert not client.is_connected
 
@@ -875,7 +903,7 @@ async def test_bleak_client_connect_error_then_cancel_during_release(
     release_disconnect = asyncio.Event()
     disconnect_finished = asyncio.Event()
 
-    async def _slow_disconnect() -> None:
+    async def _slow_disconnect(*args: Any) -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()
@@ -921,7 +949,7 @@ async def test_bleak_client_connect_services_failure_then_cancel_during_release(
     release_disconnect = asyncio.Event()
     disconnect_finished = asyncio.Event()
 
-    async def _slow_disconnect() -> None:
+    async def _slow_disconnect(*args: Any) -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()
@@ -972,7 +1000,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_shielded(
     release_disconnect = asyncio.Event()
     disconnect_finished = asyncio.Event()
 
-    async def _slow_disconnect() -> None:
+    async def _slow_disconnect(*args: Any) -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()
@@ -1047,7 +1075,7 @@ async def test_bleak_client_late_connected_callback_does_not_resurrect(
         await next(iter(client._orphan_disconnect_tasks))
 
     mock_disconnect.assert_called_once_with(
-        BLE_ADDRESS_AS_INT, timeout=DISCONNECT_TIMEOUT
+        BLE_ADDRESS_AS_INT, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
 
 
@@ -1258,7 +1286,7 @@ async def test_bleak_client_connect_get_services_cleanup_shielded(
         in_get_services.set()
         await asyncio.Event().wait()
 
-    async def _slow_disconnect() -> None:
+    async def _slow_disconnect(*args: Any) -> None:
         in_disconnect.set()
         await release_disconnect.wait()
         disconnect_finished.set()

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
@@ -617,13 +618,15 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
 @pytest.mark.asyncio
 async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logged(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Test a failing release does not mask the cancellation.
 
     If the ESP-side disconnect fails while cleaning up a cancelled
-    connect, the error is logged and swallowed; the cancellation still
-    propagates to the caller.
+    connect, the cancellation still propagates to the caller; the failure
+    is a leaked proxy slot, so it must surface as a warning rather than
+    be swallowed silently.
     """
     bleak_client, client = bleak_pair
     with (
@@ -637,6 +640,7 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
             "bluetooth_device_disconnect",
             side_effect=APIConnectionError("boom"),
         ) as mock_disconnect,
+        caplog.at_level(logging.WARNING),
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
@@ -650,6 +654,43 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
 
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
+    assert "Failed to release ESP-side connection" in caplog.text
+    assert "boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_orphan_release_cancelled_is_warned(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test a cancelled orphan release surfaces as a warning.
+
+    The orphan release is fire-and-forget; nothing else observes it, so
+    if it never completes (loop teardown mid-flight) the ESP link may
+    still be up and that must be visible in the logs.
+    """
+    _bleak_client, client = bleak_pair
+    with (
+        patch.object(
+            client,
+            "_shielded_disconnect",
+            side_effect=asyncio.CancelledError,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        fut: asyncio.Future[bool] = client._loop.create_future()
+        fut.cancel()
+        # Late connected=True for an abandoned attempt spawns the orphan
+        # release, which here ends cancelled before it can complete.
+        client._on_bluetooth_connection_state(fut, True, 23, 0)
+        assert client._orphan_disconnect_tasks
+        orphan_task = next(iter(client._orphan_disconnect_tasks))
+        with pytest.raises(asyncio.CancelledError):
+            await orphan_task
+
+    assert not client._orphan_disconnect_tasks
+    assert "release was cancelled before it completed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1190,8 +1190,10 @@ async def test_bleak_client_connect_await_signal_makes_future_terminal(
     with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
         coro = client.connect(pair=False, dangerous_use_bleak_cache=True)
         # Drive manually so the signal lands at the await itself, with
-        # the future still pending.
+        # the future still pending. The RPC already returned, so the
+        # only live suspension is ``await connected_future``.
         coro.send(None)
+        assert client._cancel_connection_state is not None
         with pytest.raises(_Signal):
             coro.throw(_Signal())
         callback = mock_connect.call_args_list[-1][0][1]
@@ -1212,6 +1214,8 @@ async def test_bleak_client_connect_await_signal_retrieves_stored_error(
     with patch_connect_rpcs(client) as (mock_connect, _mock_disconnect):
         coro = client.connect(pair=False, dangerous_use_bleak_cache=True)
         coro.send(None)
+        # Pin the suspension point to ``await connected_future``.
+        assert client._cancel_connection_state is not None
         callback = mock_connect.call_args_list[-1][0][1]
         # Fail the future, then deliver the signal before the coroutine
         # resumes.

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -1126,12 +1126,11 @@ async def test_bleak_client_connect_get_services_failure_preserves_error(
     A cleanup-disconnect failure must not mask the original connect error.
 
     When ``_get_services`` raises after the link is up, ``connect`` runs
-    ``await self._disconnect()`` to release the slot on the ESP side. If
-    that cleanup disconnect itself fails, the original ``_get_services``
-    error is the actionable one for the caller and retry logic — the
-    disconnect failure must be suppressed, mirroring the ``CancelledError``
-    cleanup branch. This asserts the surfaced ``BleakError`` carries the
-    original failure, not the disconnect error.
+    the synchronous release to free the slot on the ESP side. If that
+    release itself fails, the original ``_get_services`` error is the
+    actionable one for the caller and retry logic — the release failure
+    is logged, not raised. This asserts the release was attempted and the
+    surfaced ``BleakError`` carries the original failure.
     """
     _bleak_client, client = bleak_pair
 
@@ -1147,9 +1146,9 @@ async def test_bleak_client_connect_get_services_failure_preserves_error(
         patch.object(client, "_get_services", side_effect=_boom_get_services),
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
-            side_effect=APIConnectionError("cleanup disconnect failed"),
-        ),
+            "bluetooth_device_disconnect_no_wait",
+            side_effect=RuntimeError("cleanup disconnect failed"),
+        ) as mock_disconnect,
     ):
         task = asyncio.create_task(
             client.connect(pair=False, dangerous_use_bleak_cache=True)
@@ -1160,6 +1159,7 @@ async def test_bleak_client_connect_get_services_failure_preserves_error(
         with pytest.raises(BleakError) as exc_info:
             await task
 
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert "original get_services failure" in str(exc_info.value)
     assert "cleanup disconnect failed" not in str(exc_info.value)
 
@@ -1218,11 +1218,11 @@ async def test_bleak_client_connect_pair_failure_preserves_error(
     """
     A cleanup-disconnect failure must not mask the original pairing error.
 
-    When pairing fails after the link is up, ``connect`` runs
-    ``await self._disconnect()`` to release the slot. If that cleanup
-    disconnect itself fails, the original pairing error is the actionable
-    one for the caller — the disconnect failure must be suppressed, mirroring
-    the ``_get_services`` cleanup branch.
+    When pairing fails after the link is up, ``connect`` runs the
+    synchronous release to free the slot. If that release itself fails,
+    the original pairing error is the actionable one for the caller — the
+    release failure is logged, not raised, mirroring the ``_get_services``
+    cleanup branch.
     """
     _bleak_client, client = bleak_pair
 
@@ -1243,9 +1243,9 @@ async def test_bleak_client_connect_pair_failure_preserves_error(
         ),
         patch.object(
             client._client,
-            "bluetooth_device_disconnect",
-            side_effect=APIConnectionError("cleanup disconnect failed"),
-        ),
+            "bluetooth_device_disconnect_no_wait",
+            side_effect=RuntimeError("cleanup disconnect failed"),
+        ) as mock_disconnect,
     ):
         task = asyncio.create_task(
             client.connect(pair=True, dangerous_use_bleak_cache=True)
@@ -1256,6 +1256,7 @@ async def test_bleak_client_connect_pair_failure_preserves_error(
         with pytest.raises(BleakError) as exc_info:
             await task
 
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert "Pairing failed" in str(exc_info.value)
     assert "cleanup disconnect failed" not in str(exc_info.value)
 

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -707,17 +707,36 @@ async def test_bleak_client_connect_error_after_link_up_disconnects_esp(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("release_error", "expected_level", "expected_text"),
+    [
+        (
+            RuntimeError("boom"),
+            logging.WARNING,
+            "Failed to release ESP-side connection",
+        ),
+        (
+            APIConnectionError("api gone"),
+            logging.DEBUG,
+            "API connection gone, ESP-side release skipped",
+        ),
+    ],
+)
 async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logged(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     caplog: pytest.LogCaptureFixture,
+    release_error: Exception,
+    expected_level: int,
+    expected_text: str,
 ) -> None:
     """
     Test a failing release does not mask the cancellation.
 
-    If the ESP-side disconnect fails while cleaning up a cancelled
-    connect, the cancellation still propagates to the caller; the failure
-    is a leaked proxy slot, so it must surface as a warning rather than
-    be swallowed silently.
+    If the ESP-side release fails while cleaning up a cancelled connect,
+    the cancellation still propagates to the caller. A generic failure is
+    a leaked proxy slot and warns; a dead API connection is not a leak
+    (the proxy tears its links down once the subscriber is gone) and only
+    logs at debug so operators are not misdirected during a reconnect.
     """
     bleak_client, client = bleak_pair
     with (
@@ -729,9 +748,9 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
         patch.object(
             client._client,
             "bluetooth_device_disconnect_no_wait",
-            side_effect=APIConnectionError("boom"),
+            side_effect=release_error,
         ) as mock_disconnect,
-        caplog.at_level(logging.WARNING),
+        caplog.at_level(logging.DEBUG),
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)
@@ -742,70 +761,9 @@ async def test_bleak_client_connect_cancel_after_link_up_disconnect_failure_logg
 
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
     assert not client.is_connected
-    assert "Failed to release ESP-side connection" in caplog.text
-    assert "boom" in caplog.text
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("services_boom", "expected_error", "expected_log"),
-    [
-        (False, "while connecting", "failed connect"),
-        (True, "services boom", "failed connect setup"),
-    ],
-)
-async def test_bleak_client_connect_failure_logs_settle_timeout(
-    bleak_pair: tuple[BleakClient, ESPHomeClient],
-    caplog: pytest.LogCaptureFixture,
-    services_boom: bool,
-    expected_error: str,
-    expected_log: str,
-) -> None:
-    """
-    Test a slot that never settles after a failed attempt is logged.
-
-    Covers both failure shapes that settle before the retry: a connect
-    error after the link came up and a service discovery failure. The
-    settle timeout must not mask the original error, but it is the
-    direct cause of the next retry's entry gate failing, so it is
-    logged rather than dropped.
-    """
-    bleak_client, client = bleak_pair
-
-    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
-        raise BleakError("services boom")
-
-    with contextlib.ExitStack() as stack:
-        mock_connect = stack.enter_context(
-            patch.object(
-                client._client,
-                "bluetooth_device_connect",
-                return_value=Mock(),
-            )
-        )
-        stack.enter_context(
-            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
-        )
-        stack.enter_context(
-            patch.object(
-                client,
-                "_wait_for_free_connection_slot",
-                # First call is the connect entry gate; the second is the
-                # settle after the release, which times out.
-                side_effect=[None, TimeoutError("no slot")],
-            )
-        )
-        if services_boom:
-            stack.enter_context(
-                patch.object(client, "_get_services", side_effect=_boom_get_services)
-            )
-        stack.enter_context(caplog.at_level(logging.DEBUG))
-        task, callback = await start_connect(bleak_client, mock_connect)
-        callback(True, 23, 0 if services_boom else 1)
-        with pytest.raises(BleakError, match=expected_error):
-            await task
-
-    assert f"Slot did not settle after {expected_log}" in caplog.text
+    matching = [record for record in caplog.records if expected_text in record.message]
+    assert len(matching) == 1
+    assert matching[0].levelno == expected_level
 
 
 @pytest.mark.asyncio
@@ -1013,6 +971,110 @@ async def test_bleak_client_connect_outer_base_exception_cleans_up(
     assert not client.is_connected
     mock_cancel_connection_state.assert_called_once_with()
     assert client._cancel_connection_state is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("services_boom", "expected_error", "expected_log"),
+    [
+        (False, "while connecting", "failed connect"),
+        (True, "services boom", "failed connect setup"),
+    ],
+)
+async def test_bleak_client_connect_failure_logs_settle_timeout(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
+    services_boom: bool,
+    expected_error: str,
+    expected_log: str,
+) -> None:
+    """
+    Test a slot that never settles after a failed attempt is logged.
+
+    Covers both failure shapes that settle before the retry: a connect
+    error after the link came up and a service discovery failure. The
+    settle timeout must not mask the original error, but it is the
+    direct cause of the next retry's entry gate failing, so it is
+    logged rather than dropped.
+    """
+    bleak_client, client = bleak_pair
+
+    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+        raise BleakError("services boom")
+
+    with contextlib.ExitStack() as stack:
+        mock_connect = stack.enter_context(
+            patch.object(
+                client._client,
+                "bluetooth_device_connect",
+                return_value=Mock(),
+            )
+        )
+        stack.enter_context(
+            patch.object(client._client, "bluetooth_device_disconnect_no_wait")
+        )
+        stack.enter_context(
+            patch.object(
+                client,
+                "_wait_for_free_connection_slot",
+                # First call is the connect entry gate; the second is the
+                # settle after the release, which times out.
+                side_effect=[None, TimeoutError("no slot")],
+            )
+        )
+        if services_boom:
+            stack.enter_context(
+                patch.object(client, "_get_services", side_effect=_boom_get_services)
+            )
+        stack.enter_context(caplog.at_level(logging.DEBUG))
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 0 if services_boom else 1)
+        with pytest.raises(BleakError, match=expected_error):
+            await task
+
+    assert f"Slot did not settle after {expected_log}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_get_services_signal_releases_without_settle(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a signal during service discovery releases without settling.
+
+    A ``BaseException`` from the post-connect setup must not be stalled
+    behind the slot settle; the link is still released.
+    """
+
+    class _Signal(BaseException):
+        """Stand-in for KeyboardInterrupt that pytest does not intercept."""
+
+    bleak_client, client = bleak_pair
+
+    async def _boom_get_services(*args: Any, **kwargs: Any) -> Any:
+        raise _Signal
+
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(client, "_get_services", side_effect=_boom_get_services),
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect_no_wait",
+        ) as mock_disconnect,
+        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+    ):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        callback(True, 23, 0)
+        with pytest.raises(_Signal):
+            await task
+
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+    mock_settle.assert_not_awaited()
+    assert not client.is_connected
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -641,7 +641,7 @@ async def test_bleak_client_connect_error_without_link_cleans_up_locally(
 
     A ``connected=False`` error resolution means the ESP holds nothing;
     only the local cleanup runs, no disconnect is sent, and the settle
-    still runs before the retry.
+    is skipped since the attempt never held a slot.
     """
     bleak_client, client = bleak_pair
     with (

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -20,6 +20,7 @@ from bleak.exc import BleakError
 from habluetooth import BaseHaRemoteScanner, HaBluetoothConnector
 
 from bleak_esphome.backend.client import (
+    CONNECT_FREE_SLOT_TIMEOUT,
     GATT_HEADER_SIZE,
     ESPHomeClient,
     ESPHomeClientData,
@@ -560,6 +561,33 @@ async def test_bleak_client_connect_real_task_cancel_propagates_outer(
         assert not client.is_connected
         assert client._async_esp_disconnected not in client._disconnect_callbacks
 
+    mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_racing_link_up_releases(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a link up racing a real cancel is released by the abandonment.
+
+    ``task.cancel()`` cancels ``connected_future`` synchronously; if the
+    ESP's ``connected=True`` then arrives before the task resumes, the
+    attempt's subscription is still installed, so the callback defers to
+    the unwinding attempt's abandonment, which must release the link
+    rather than treating the attempt as never having connected.
+    """
+    bleak_client, client = bleak_pair
+    with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        assert task.cancel() is True
+        # The future is already cancelled; the link comes up before the
+        # task resumes.
+        callback(True, 23, 0)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+    assert not client.is_connected
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
 
 
@@ -1167,7 +1195,7 @@ async def test_bleak_client_connect_failure_logs_settle_timeout(
             # First call is the connect entry gate; the second is the
             # settle after the release, which times out.
             side_effect=[None, TimeoutError("no slot")],
-        ),
+        ) as mock_wait,
         contextlib.ExitStack() as failure_stack,
         caplog.at_level(logging.DEBUG),
     ):
@@ -1181,6 +1209,9 @@ async def test_bleak_client_connect_failure_logs_settle_timeout(
             await task
 
     assert f"Slot did not settle after {expected_log}" in caplog.text
+    # The settle is capped to the same window as the next attempt's
+    # entry gate; a longer budget only delays surfacing the error.
+    assert mock_wait.call_args_list[-1][0] == (CONNECT_FREE_SLOT_TIMEOUT,)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -588,7 +588,39 @@ async def test_bleak_client_connect_cancel_racing_link_up_releases(
             await task
         assert task.cancelled()
     assert not client.is_connected
+    assert not client._pending_release
     mock_disconnect.assert_called_once_with(BLE_ADDRESS_AS_INT)
+
+
+@pytest.mark.asyncio
+async def test_bleak_client_connect_cancel_racing_link_up_then_drop(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """
+    Test a deferred link up followed by a drop stays silent to the consumer.
+
+    The abandoned attempt never handed the connection to the caller, so
+    a ``connected=False`` racing in before the task resumes must not
+    fire (or null) the consumer's disconnected_callback, and the
+    abandonment has nothing left to release because the ESP already
+    dropped the link.
+    """
+    bleak_client, client = bleak_pair
+    disconnected_callback = Mock()
+    client._disconnected_callback = disconnected_callback
+    with patch_connect_rpcs(client) as (mock_connect, mock_disconnect):
+        task, callback = await start_connect(bleak_client, mock_connect)
+        assert task.cancel() is True
+        callback(True, 23, 0)
+        callback(False, 23, 0)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+    assert not client.is_connected
+    assert not client._pending_release
+    disconnected_callback.assert_not_called()
+    assert client._disconnected_callback is disconnected_callback
+    mock_disconnect.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -199,11 +199,9 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     """
     A ``connected=True`` callback with a completed future is ignored.
 
-    The future being done means the connect attempt already finished
-    (failed, timed out, or was cancelled) and the owning ``connect()``
-    has bailed; a late connected notification must not flip
-    ``_is_connected`` back on or cache the reported MTU. It must release
-    the just-established ESP-side link instead of leaving it orphaned.
+    Unit-level twin of the ``connect()``-path test in ``test_client.py``:
+    drives the callback directly with a cancelled future and additionally
+    guards that the reported MTU is not cached for the abandoned attempt.
     """
     client = _make_client(client_data)
     client._bluetooth_device.ble_connections_free = 1
@@ -216,8 +214,8 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         client._on_bluetooth_connection_state(fut, True, 23, 0)
         assert not client.is_connected
         assert client._mtu is None
-        assert client._orphan_disconnect_task is not None
-        await client._orphan_disconnect_task
+        assert client._orphan_disconnect_tasks
+        await next(iter(client._orphan_disconnect_tasks))
     mock_disconnect.assert_called_once_with(client._address_as_int)
 
 
@@ -497,9 +495,7 @@ async def test_connect_get_services_failure_disconnects(
             return_value=Mock(),
         ) as mock_connect,
         patch.object(client, "_get_services", side_effect=_boom),
-        patch.object(
-            client, "_disconnect", new=AsyncMock(return_value=True)
-        ) as mock_disc,
+        patch.object(client, "_disconnect_no_wait", new=AsyncMock()) as mock_disc,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -206,10 +206,12 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     must not cache the reported MTU or resolve anything. With the
     subscription already gone the orphaned link is released directly.
     With the subscription still installed the owning ``connect()`` has
-    not unwound yet, so the callback defers: it marks the link up and
-    sends nothing, leaving the release to that attempt's abandonment
-    (covered end to end by
-    ``test_bleak_client_connect_cancel_racing_link_up_releases``).
+    not unwound yet, so the callback defers: it flags the release as
+    pending and sends nothing, leaving the release to that attempt's
+    abandonment (covered end to end by
+    ``test_bleak_client_connect_cancel_racing_link_up_releases``). The
+    dedicated flag keeps ``_is_connected`` false so the abandoned
+    attempt can never look consumer-owned.
     """
     client = _make_client(client_data)
     if in_flight:
@@ -221,7 +223,8 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         "bluetooth_device_disconnect_no_wait",
     ) as mock_disconnect:
         client._on_bluetooth_connection_state(fut, True, 23, 0)
-        assert client._is_connected is in_flight
+        assert not client._is_connected
+        assert client._pending_release is in_flight
         assert client._mtu is None
     if in_flight:
         mock_disconnect.assert_not_called()

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -202,14 +202,23 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     The future being done means the connect attempt already finished
     (failed, timed out, or was cancelled) and the owning ``connect()``
     has bailed; a late connected notification must not flip
-    ``_is_connected`` back on or cache the reported MTU.
+    ``_is_connected`` back on or cache the reported MTU. It must release
+    the just-established ESP-side link instead of leaving it orphaned.
     """
     client = _make_client(client_data)
+    client._bluetooth_device.ble_connections_free = 1
     fut: asyncio.Future[bool] = client._loop.create_future()
     fut.cancel()
-    client._on_bluetooth_connection_state(fut, True, 23, 0)
-    assert not client.is_connected
-    assert client._mtu is None
+    with patch.object(
+        client._client,
+        "bluetooth_device_disconnect",
+    ) as mock_disconnect:
+        client._on_bluetooth_connection_state(fut, True, 23, 0)
+        assert not client.is_connected
+        assert client._mtu is None
+        assert client._orphan_disconnect_task is not None
+        await client._orphan_disconnect_task
+    mock_disconnect.assert_called_once_with(client._address_as_int)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -193,6 +193,26 @@ async def test_on_bluetooth_connection_state_idempotent_when_future_done(
 
 
 @pytest.mark.asyncio
+async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
+    client_data: ESPHomeClientData,
+) -> None:
+    """
+    A ``connected=True`` callback with a completed future is ignored.
+
+    The future being done means the connect attempt already finished
+    (failed, timed out, or was cancelled) and the owning ``connect()``
+    has bailed; a late connected notification must not flip
+    ``_is_connected`` back on or cache the reported MTU.
+    """
+    client = _make_client(client_data)
+    fut: asyncio.Future[bool] = client._loop.create_future()
+    fut.cancel()
+    client._on_bluetooth_connection_state(fut, True, 23, 0)
+    assert not client.is_connected
+    assert client._mtu is None
+
+
+@pytest.mark.asyncio
 async def test_on_bluetooth_connection_state_preserves_cached_mtu(
     client_data: ESPHomeClientData,
 ) -> None:

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -193,17 +193,25 @@ async def test_on_bluetooth_connection_state_idempotent_when_future_done(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("in_flight", [False, True])
 async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     client_data: ESPHomeClientData,
+    in_flight: bool,
 ) -> None:
     """
     A ``connected=True`` callback with a completed future is ignored.
 
-    Unit-level twin of the ``connect()``-path test in ``test_client.py``:
-    drives the callback directly with a cancelled future and additionally
-    guards that the reported MTU is not cached for the abandoned attempt.
+    The future being done means the connect attempt already finished
+    (failed, timed out, or was cancelled) and the owning ``connect()``
+    has bailed; a late connected notification must not flip
+    ``_is_connected`` back on or cache the reported MTU. The orphaned
+    link is released unless a newer attempt is in flight on this
+    instance (marked by a live connection-state subscription), in which
+    case releasing by address would tear that attempt down.
     """
     client = _make_client(client_data)
+    if in_flight:
+        client._cancel_connection_state = Mock()
     fut: asyncio.Future[bool] = client._loop.create_future()
     fut.cancel()
     with patch.object(
@@ -213,7 +221,10 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         client._on_bluetooth_connection_state(fut, True, 23, 0)
         assert not client.is_connected
         assert client._mtu is None
-    mock_disconnect.assert_called_once_with(client._address_as_int)
+    if in_flight:
+        mock_disconnect.assert_not_called()
+    else:
+        mock_disconnect.assert_called_once_with(client._address_as_int)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -36,7 +36,7 @@ from bleak.exc import BleakError
 from pytest_asyncio import fixture as aio_fixture
 
 from bleak_esphome.backend.client import (
-    DISCONNECT_TIMEOUT,
+    SHIELDED_DISCONNECT_TIMEOUT,
     ESPHomeClient,
     ESPHomeClientData,
 )
@@ -221,7 +221,7 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         assert client._orphan_disconnect_tasks
         await next(iter(client._orphan_disconnect_tasks))
     mock_disconnect.assert_called_once_with(
-        client._address_as_int, timeout=DISCONNECT_TIMEOUT
+        client._address_as_int, timeout=SHIELDED_DISCONNECT_TIMEOUT
     )
 
 

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -199,15 +199,17 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     in_flight: bool,
 ) -> None:
     """
-    A ``connected=True`` callback with a completed future is ignored.
+    A ``connected=True`` callback with a completed future is not resurrected.
 
     The future being done means the connect attempt already finished
-    (failed, timed out, or was cancelled) and the owning ``connect()``
-    has bailed; a late connected notification must not flip
-    ``_is_connected`` back on or cache the reported MTU. The orphaned
-    link is released unless a newer attempt is in flight on this
-    instance (marked by a live connection-state subscription), in which
-    case releasing by address would tear that attempt down.
+    (failed, timed out, or was cancelled); a late connected notification
+    must not cache the reported MTU or resolve anything. With the
+    subscription already gone the orphaned link is released directly.
+    With the subscription still installed the owning ``connect()`` has
+    not unwound yet, so the callback defers: it marks the link up and
+    sends nothing, leaving the release to that attempt's abandonment
+    (covered end to end by
+    ``test_bleak_client_connect_cancel_racing_link_up_releases``).
     """
     client = _make_client(client_data)
     if in_flight:
@@ -219,7 +221,7 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         "bluetooth_device_disconnect_no_wait",
     ) as mock_disconnect:
         client._on_bluetooth_connection_state(fut, True, 23, 0)
-        assert not client.is_connected
+        assert client._is_connected is in_flight
         assert client._mtu is None
     if in_flight:
         mock_disconnect.assert_not_called()
@@ -490,7 +492,7 @@ async def test_stop_notify_missing_handle_is_noop(
 async def test_connect_get_services_failure_disconnects(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:
-    """A non-cancel failure in ``_get_services`` runs ``_disconnect``."""
+    """A non-cancel failure in ``_get_services`` releases the ESP link."""
     bleak_client, client = bleak_pair
 
     async def _boom(*args: Any, **kwargs: Any) -> Any:

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -35,11 +35,7 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 from pytest_asyncio import fixture as aio_fixture
 
-from bleak_esphome.backend.client import (
-    SHIELDED_DISCONNECT_TIMEOUT,
-    ESPHomeClient,
-    ESPHomeClientData,
-)
+from bleak_esphome.backend.client import ESPHomeClient, ESPHomeClientData
 
 from ._helpers import ESP_MAC_ADDRESS, _make_client
 
@@ -208,21 +204,16 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
     guards that the reported MTU is not cached for the abandoned attempt.
     """
     client = _make_client(client_data)
-    client._bluetooth_device.ble_connections_free = 1
     fut: asyncio.Future[bool] = client._loop.create_future()
     fut.cancel()
     with patch.object(
         client._client,
-        "bluetooth_device_disconnect",
+        "bluetooth_device_disconnect_no_wait",
     ) as mock_disconnect:
         client._on_bluetooth_connection_state(fut, True, 23, 0)
         assert not client.is_connected
         assert client._mtu is None
-        assert client._orphan_disconnect_tasks
-        await next(iter(client._orphan_disconnect_tasks))
-    mock_disconnect.assert_called_once_with(
-        client._address_as_int, timeout=SHIELDED_DISCONNECT_TIMEOUT
-    )
+    mock_disconnect.assert_called_once_with(client._address_as_int)
 
 
 @pytest.mark.asyncio
@@ -501,7 +492,7 @@ async def test_connect_get_services_failure_disconnects(
             return_value=Mock(),
         ) as mock_connect,
         patch.object(client, "_get_services", side_effect=_boom),
-        patch.object(client, "_disconnect_no_wait", new=AsyncMock()) as mock_disc,
+        patch.object(client, "_release_connection_no_wait", new=Mock()) as mock_disc,
     ):
         task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
         await asyncio.sleep(0)
@@ -511,7 +502,7 @@ async def test_connect_get_services_failure_disconnects(
         callback(True, 23, 0)
         with pytest.raises(RuntimeError, match="services boom"):
             await task
-    mock_disc.assert_awaited_once()
+    mock_disc.assert_called_once_with()
 
 
 @pytest.fixture

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -35,7 +35,11 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 from pytest_asyncio import fixture as aio_fixture
 
-from bleak_esphome.backend.client import ESPHomeClient, ESPHomeClientData
+from bleak_esphome.backend.client import (
+    DISCONNECT_TIMEOUT,
+    ESPHomeClient,
+    ESPHomeClientData,
+)
 
 from ._helpers import ESP_MAC_ADDRESS, _make_client
 
@@ -216,7 +220,9 @@ async def test_on_bluetooth_connection_state_late_connect_does_not_resurrect(
         assert client._mtu is None
         assert client._orphan_disconnect_tasks
         await next(iter(client._orphan_disconnect_tasks))
-    mock_disconnect.assert_called_once_with(client._address_as_int)
+    mock_disconnect.assert_called_once_with(
+        client._address_as_int, timeout=DISCONNECT_TIMEOUT
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A connect attempt can be cancelled after the proxy already reported the link up; asyncio still delivers the CancelledError at the await even though the future holds a result. The old cancel path only removed the connection state subscription, so the ESP kept a live connection nobody owned and its slot was never freed until the whole API connection dropped. With bleak_retry_connector hopping to another proxy on the next attempt, the same address ends up allocated on several proxies at once, which is one of the leaks behind home-assistant/core#176516.

Every abandonment path now releases the ESP side connection with one synchronous send via aioesphomeapi's bluetooth_device_disconnect_no_wait (added in 45.12.0 for this): cancel after link up, error after link up, setup failure, a real signal, and a late connected callback for an attempt nobody owns anymore, which releases inline when no attempt is unwinding, or defers to the unwinding attempt's abandonment when its subscription is still installed. Because the release contains no await, cancellation has no window to land mid release and propagates immediately; the only remaining await on the failure paths is the slot settle before a retry, capped to the same window the next attempt's entry gate waits, where a cancel propagates naturally and outranks the original error. A failed send logs a warning since it means a leaked proxy slot, except a dead API connection which logs at debug because the proxy tears its own links down once the subscriber is gone. Abandoned attempts are made terminal so a late callback cannot resurrect state, and the public disconnect() path still awaits the ESP's confirmation unchanged.

Abandonment is silent to the consumer on the failure paths this touches: the pairing and service discovery failure paths previously fired the bleak disconnected_callback for a connection the caller never received (and nulled it for good), which this also fixes. A device genuinely dropping the link while pairing or service discovery is still running keeps its pre-existing behavior of notifying the consumer; tightening that shape is left for a follow-up.
