### PR TITLE
fix: reconcile client connected state with proxy allocated slot list

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,7 +157,8 @@ addresses; if a client this library believes is connected is missing from
 that list, the proxy no longer holds the connection — its `connected=false`
 notification was lost (congested link, or the proxy rebooted) — and the
 client is disconnected locally so the consumer can reconnect instead of
-holding a phantom connection forever. The DEBUG log line for this path is:
+holding a phantom connection forever. Because it means the proxy and the
+host were out of sync, this path logs a WARNING:
 
 ```
 <name> [<mac>]: Reconciling stale connection to <address>: not in allocated list [...]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -165,10 +165,11 @@ host were out of sync, this path logs a WARNING:
 ```
 
 The list is only trusted when its length matches the used slot count
-(`limit - free`). Firmware that predates the allocated list reports used
-slots with an empty list, and an in-flight connect consumes a slot before
-its address appears; both produce a mismatch and skip reconciliation, so
-neither can tear down a healthy client.
+(`limit - free`). Firmware maintains the two as one fact, an address enters
+the list when its slot is reserved, before the link is even attempted, so
+they always match when the list is reported at all. Firmware that predates
+the allocated list reports used slots with an empty list; that mismatch
+skips reconciliation, so it cannot tear down a healthy client.
 
 ## Connect attempts are rejected by `bleak` before the proxy is ever called
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,6 +148,27 @@ give each proxy a clearly stronger signal for its intended device (position
 and antenna orientation), and avoid having two proxies with near-identical
 RSSI competing for the same peripheral.
 
+## My `disconnected_callback` fired without a disconnect event in the logs
+
+A connected client can be torn down by allocation reconciliation, without a
+`connected=false` notification ever arriving. Every connection-slot update
+from the proxy carries the authoritative list of allocated (connected)
+addresses; if a client this library believes is connected is missing from
+that list, the proxy no longer holds the connection — its `connected=false`
+notification was lost (congested link, or the proxy rebooted) — and the
+client is disconnected locally so the consumer can reconnect instead of
+holding a phantom connection forever. The DEBUG log line for this path is:
+
+```
+<name> [<mac>]: Reconciling stale connection to <address>: not in allocated list [...]
+```
+
+The list is only trusted when its length matches the used slot count
+(`limit - free`). Firmware that predates the allocated list reports used
+slots with an empty list, and an in-flight connect consumes a slot before
+its address appears; both produce a mismatch and skip reconciliation, so
+neither can tear down a healthy client.
+
 ## Connect attempts are rejected by `bleak` before the proxy is ever called
 
 The scanner is registered as non-connectable. This happens when the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,7 +155,8 @@ A connected client can be torn down by allocation reconciliation, without a
 from the proxy carries the authoritative list of allocated (connected)
 addresses; if a client this library believes is connected is missing from
 that list, the proxy no longer holds the connection — its `connected=false`
-notification was lost (congested link, or the proxy rebooted) — and the
+notification was lost (a congested link, or an ESP-side link loss that
+never produced one) — and the
 client is disconnected locally so the consumer can reconnect instead of
 holding a phantom connection forever. Because it means the proxy and the
 host were out of sync, this path logs a WARNING:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -189,6 +189,9 @@ class ESPHomeClient(BaseBleakClient):
             notify_abort()
         self._notify_cancels.clear()
         self._disconnect_callbacks.discard(self._async_esp_disconnected)
+        self._bluetooth_device.async_untrack_client(
+            self._address_as_int, self._async_ble_device_disconnected
+        )
         if self._cancel_connection_state:
             self._cancel_connection_state()
             self._cancel_connection_state = None
@@ -267,6 +270,9 @@ class ESPHomeClient(BaseBleakClient):
             self._description,
         )
         self._disconnect_callbacks.add(self._async_esp_disconnected)
+        self._bluetooth_device.async_track_client(
+            self._address_as_int, self._async_ble_device_disconnected
+        )
         connected_future.set_result(connected)
 
     @api_error_as_bleak_error

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -155,12 +155,16 @@ class ESPHomeBluetoothDevice:
                 int_to_bluetooth_address(address),
                 allocated,
             )
+            # Untrack before invoking so the teardown is attempted exactly
+            # once; if the handler raises partway (it ends in consumer
+            # supplied code) the entry must not linger and re-fire the
+            # warning plus traceback on every later slot update.
+            self.async_untrack_client(address, on_ble_disconnected)
             try:
                 on_ble_disconnected()
             except Exception:  # pylint: disable=broad-except
-                # The handler ends in consumer supplied code; one raising
-                # must not strand the remaining stale clients until the
-                # next slot change.
+                # One raising handler must not strand the remaining stale
+                # clients until the next slot change.
                 _LOGGER.exception(
                     "%s [%s]: Error reconciling stale connection to %s",
                     self.name,

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -119,11 +119,13 @@ class ESPHomeBluetoothDevice:
         tears down the client state and lets the consumer reconnect
         instead of holding a phantom connection forever.
 
-        Only trusted when the list length matches the used slot count:
-        older firmware reports ``free``/``limit`` without ``allocated``
-        (indistinguishable from an empty list), and an in-flight connect
-        consumes a slot before its address appears in the list; both
-        yield a mismatch and are skipped.
+        Only trusted when the list length matches the used slot count.
+        Firmware maintains ``free`` and ``allocated`` as one fact (an
+        address enters the list at slot reservation, before the link is
+        even attempted), so the lengths always match on firmware that
+        reports the list; older firmware reports ``free``/``limit`` with
+        no ``allocated`` at all, which looks like an empty list, and the
+        mismatch skips reconciliation so nothing is torn down on it.
         """
         allocated = self.ble_allocations
         used = self.ble_connections_limit - self.ble_connections_free
@@ -153,7 +155,18 @@ class ESPHomeBluetoothDevice:
                 int_to_bluetooth_address(address),
                 allocated,
             )
-            on_ble_disconnected()
+            try:
+                on_ble_disconnected()
+            except Exception:  # pylint: disable=broad-except
+                # The handler ends in consumer supplied code; one raising
+                # must not strand the remaining stale clients until the
+                # next slot change.
+                _LOGGER.exception(
+                    "%s [%s]: Error reconciling stale connection to %s",
+                    self.name,
+                    self.mac_address,
+                    int_to_bluetooth_address(address),
+                )
 
     def _wait_for_ble_connections_free_timeout(self, fut: asyncio.Future[int]) -> None:
         """Timeout the wait_for_ble_connections_free future."""

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -34,6 +34,8 @@ class ESPHomeBluetoothDevice:
     _connection_slots_callback: Callable[[Allocations], None] | None = None
     _called_callback: bool = False
     _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
+    _seen_allocated: bool = False
+    _warned_untrusted: bool = False
 
     def async_subscribe_connection_slots(
         self, callback: Callable[[Allocations], None]
@@ -51,6 +53,18 @@ class ESPHomeBluetoothDevice:
         ``on_ble_disconnected`` is invoked when the proxy's authoritative
         allocated list no longer contains ``address``.
         """
+        if (
+            existing := self._tracked_clients.get(address)
+        ) is not None and existing != on_ble_disconnected:
+            # The displaced client loses this reconciliation backstop; it
+            # still holds its own subscription and disconnect callback,
+            # but the overlap is worth a trace in a bug report.
+            _LOGGER.debug(
+                "%s [%s]: Replacing tracked client for %s",
+                self.name,
+                self.mac_address,
+                int_to_bluetooth_address(address),
+            )
         self._tracked_clients[address] = on_ble_disconnected
 
     def async_untrack_client(
@@ -133,8 +147,26 @@ class ESPHomeBluetoothDevice:
         """
         allocated = self.ble_allocations
         used = self.ble_connections_limit - self.ble_connections_free
+        if allocated:
+            self._seen_allocated = True
         if len(allocated) != used:
-            if self._tracked_clients:
+            if self._seen_allocated and not self._warned_untrusted:
+                # This firmware does report the list, so a mismatch is a
+                # genuine slot accounting anomaly on the proxy that
+                # disables the phantom connection heal; surface it once
+                # rather than hiding it at debug like the legacy
+                # firmware case below.
+                self._warned_untrusted = True
+                _LOGGER.warning(
+                    "%s [%s]: Proxy slot accounting is inconsistent"
+                    " (used=%s allocated=%s); connection reconciliation"
+                    " is disabled until it matches again",
+                    self.name,
+                    self.mac_address,
+                    used,
+                    allocated,
+                )
+            elif self._tracked_clients:
                 _LOGGER.debug(
                     "%s [%s]: Skipping connection reconcile, allocated list"
                     " not trusted: used=%s allocated=%s",
@@ -144,6 +176,9 @@ class ESPHomeBluetoothDevice:
                     allocated,
                 )
             return
+        # A matching update re-arms the anomaly warning so a recurring
+        # inconsistency is visible again after a recovery.
+        self._warned_untrusted = False
         # Snapshot: handlers untrack themselves during the loop.
         for address, on_ble_disconnected in list(self._tracked_clients.items()):
             if address in allocated:

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -142,7 +142,10 @@ class ESPHomeBluetoothDevice:
         for address, on_ble_disconnected in list(self._tracked_clients.items()):
             if address in allocated:
                 continue
-            _LOGGER.debug(
+            # Warning: this means the proxy's connected=false notification
+            # was lost (congested link or proxy reboot); the state was out
+            # of sync until this self heal.
+            _LOGGER.warning(
                 "%s [%s]: Reconciling stale connection to %s: "
                 "not in allocated list %s",
                 self.name,

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -94,6 +94,10 @@ class ESPHomeBluetoothDevice:
                 if not fut.done():
                     fut.set_result(free)
             self._ble_connection_free_futures.clear()
+        # Heal local client state before notifying subscribers so the
+        # published allocation snapshot and the clients' connected state
+        # are always consistent with each other.
+        self._async_reconcile_connections()
         if (changed or not self._called_callback) and (
             connection_slots_callback := self._connection_slots_callback
         ):
@@ -106,7 +110,6 @@ class ESPHomeBluetoothDevice:
                     [int_to_bluetooth_address(address) for address in allocated],
                 )
             )
-        self._async_reconcile_connections()
 
     def _async_reconcile_connections(self) -> None:
         """
@@ -115,7 +118,8 @@ class ESPHomeBluetoothDevice:
         The allocated list is authoritative for which addresses hold a
         connection on the proxy, so a tracked client missing from it lost
         its connection and the ``connected=false`` notification was lost
-        (congested link or proxy reboot). Firing its disconnect handler
+        (congested link, or an ESP-side link loss that never produced a
+        notification). Firing its disconnect handler
         tears down the client state and lets the consumer reconnect
         instead of holding a phantom connection forever.
 
@@ -145,8 +149,9 @@ class ESPHomeBluetoothDevice:
             if address in allocated:
                 continue
             # Warning: this means the proxy's connected=false notification
-            # was lost (congested link or proxy reboot); the state was out
-            # of sync until this self heal.
+            # was lost (congested link, or an ESP-side link loss that
+            # never produced one); the state was out of sync until this
+            # self heal.
             _LOGGER.warning(
                 "%s [%s]: Reconciling stale connection to %s: "
                 "not in allocated list %s",

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -33,6 +33,7 @@ class ESPHomeBluetoothDevice:
     cache: ESPHomeBluetoothCache = field(default_factory=ESPHomeBluetoothCache)
     _connection_slots_callback: Callable[[Allocations], None] | None = None
     _called_callback: bool = False
+    _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
 
     def async_subscribe_connection_slots(
         self, callback: Callable[[Allocations], None]
@@ -40,6 +41,29 @@ class ESPHomeBluetoothDevice:
         """Subscribe to connection slot changes."""
         self._connection_slots_callback = callback
         self._called_callback = False
+
+    def async_track_client(
+        self, address: int, on_ble_disconnected: Callable[[], None]
+    ) -> None:
+        """
+        Track a connected client so it can be reconciled against allocations.
+
+        ``on_ble_disconnected`` is invoked when the proxy's authoritative
+        allocated list no longer contains ``address``.
+        """
+        self._tracked_clients[address] = on_ble_disconnected
+
+    def async_untrack_client(
+        self, address: int, on_ble_disconnected: Callable[[], None]
+    ) -> None:
+        """
+        Stop tracking a connected client.
+
+        Only removes the entry when it still belongs to the same client;
+        a newer client may already have replaced it for this address.
+        """
+        if self._tracked_clients.get(address) == on_ble_disconnected:
+            del self._tracked_clients[address]
 
     def async_update_ble_connection_limits(
         self, free: int, limit: int, allocated: list[int]
@@ -82,6 +106,51 @@ class ESPHomeBluetoothDevice:
                     [int_to_bluetooth_address(address) for address in allocated],
                 )
             )
+        self._async_reconcile_connections()
+
+    def _async_reconcile_connections(self) -> None:
+        """
+        Disconnect tracked clients absent from the proxy's allocated list.
+
+        The allocated list is authoritative for which addresses hold a
+        connection on the proxy, so a tracked client missing from it lost
+        its connection and the ``connected=false`` notification was lost
+        (congested link or proxy reboot). Firing its disconnect handler
+        tears down the client state and lets the consumer reconnect
+        instead of holding a phantom connection forever.
+
+        Only trusted when the list length matches the used slot count:
+        older firmware reports ``free``/``limit`` without ``allocated``
+        (indistinguishable from an empty list), and an in-flight connect
+        consumes a slot before its address appears in the list; both
+        yield a mismatch and are skipped.
+        """
+        allocated = self.ble_allocations
+        used = self.ble_connections_limit - self.ble_connections_free
+        if len(allocated) != used:
+            if self._tracked_clients:
+                _LOGGER.debug(
+                    "%s [%s]: Skipping connection reconcile, allocated list"
+                    " not trusted: used=%s allocated=%s",
+                    self.name,
+                    self.mac_address,
+                    used,
+                    allocated,
+                )
+            return
+        # Snapshot: handlers untrack themselves during the loop.
+        for address, on_ble_disconnected in list(self._tracked_clients.items()):
+            if address in allocated:
+                continue
+            _LOGGER.debug(
+                "%s [%s]: Reconciling stale connection to %s: "
+                "not in allocated list %s",
+                self.name,
+                self.mac_address,
+                int_to_bluetooth_address(address),
+                allocated,
+            )
+            on_ble_disconnected()
 
     def _wait_for_ble_connections_free_timeout(self, fut: asyncio.Future[int]) -> None:
         """Timeout the wait_for_ble_connections_free future."""

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -344,6 +344,53 @@ async def test_bleak_client_connect(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_reconciled_when_missing_from_allocations(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
+) -> None:
+    """
+    Test a connected client is torn down when the proxy no longer lists it.
+
+    Covers the phantom-connection heal: the ``connected=false``
+    notification was lost, so only the allocated list reveals the loss.
+    """
+    bleak_client, client = bleak_pair
+    bluetooth_device = client._bluetooth_device
+    with (
+        patch.object(
+            client._client,
+            "bluetooth_device_connect",
+            return_value=Mock(),
+        ) as mock_connect,
+        patch.object(
+            client._client,
+            "bluetooth_gatt_get_services",
+            return_value=esphome_bluetooth_gatt_services,
+        ),
+    ):
+        task = asyncio.create_task(bleak_client.connect(dangerous_use_bleak_cache=True))
+        await asyncio.sleep(0)
+        callback = mock_connect.call_args_list[0][0][1]
+        callback(True, 23, 0)
+        await task
+
+    assert client._is_connected
+    disconnected_callback = Mock()
+    client._disconnected_callback = disconnected_callback
+
+    # A trusted update that still lists the client leaves it connected.
+    bluetooth_device.async_update_ble_connection_limits(1, 2, [BLE_ADDRESS_AS_INT])
+    assert client._is_connected
+    disconnected_callback.assert_not_called()
+
+    # The proxy reports the address gone: the client must be torn down.
+    bluetooth_device.async_update_ble_connection_limits(2, 2, [])
+    assert not client.is_connected
+    disconnected_callback.assert_called_once_with()
+    assert client._async_esp_disconnected not in client._disconnect_callbacks
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_connect_connected_future_cancelled_raises_bleak_error(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -88,15 +89,20 @@ async def test_reconcile_skips_untrusted_allocated_list(
 @pytest.mark.asyncio
 async def test_reconcile_only_disconnects_missing_addresses(
     bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Only the clients missing from the allocated list are disconnected."""
     stale = Mock()
     live = Mock()
     bluetooth_device.async_track_client(42, stale)
     bluetooth_device.async_track_client(43, live)
-    bluetooth_device.async_update_ble_connection_limits(2, 3, [43])
+    with caplog.at_level(logging.WARNING):
+        bluetooth_device.async_update_ble_connection_limits(2, 3, [43])
     stale.assert_called_once_with()
     live.assert_not_called()
+    # Out of sync state is a failure somewhere; it must surface without
+    # debug logging enabled.
+    assert "Reconciling stale connection" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -135,6 +135,52 @@ async def test_reconcile_isolates_raising_handler(
 
 
 @pytest.mark.asyncio
+async def test_track_client_logs_when_displacing_existing_entry(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Displacing a tracked client for the same address leaves a trace."""
+    old_handler = Mock()
+    new_handler = Mock()
+    bluetooth_device.async_track_client(42, old_handler)
+    with caplog.at_level(logging.DEBUG):
+        bluetooth_device.async_track_client(42, new_handler)
+    assert "Replacing tracked client" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reconcile_warns_once_on_slot_accounting_anomaly(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A mismatch on list-reporting firmware warns once until it recovers.
+
+    Legacy firmware that never reports the list stays at debug; firmware
+    that has reported it and then mismatches has a genuine accounting
+    anomaly that disables the heal, which must be visible in production
+    logs, once per episode.
+    """
+    handler = Mock()
+    bluetooth_device.async_track_client(42, handler)
+    with caplog.at_level(logging.WARNING):
+        # Legacy-looking mismatch before any list was seen: no warning.
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [])
+        assert "slot accounting is inconsistent" not in caplog.text
+        # The list is reported, then mismatches: warn once.
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [42, 43])
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+        assert caplog.text.count("slot accounting is inconsistent") == 1
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [43])
+        assert caplog.text.count("slot accounting is inconsistent") == 1
+        # A matching update re-arms the warning for the next episode.
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [42, 43])
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+        assert caplog.text.count("slot accounting is inconsistent") == 2
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_untrack_client_only_removes_matching_handler(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -76,9 +76,9 @@ async def test_reconcile_skips_untrusted_allocated_list(
     """
     An allocated list shorter than the used slot count is not trusted.
 
-    Older firmware reports free/limit without the allocated list, and an
-    in-flight connect consumes a slot before its address appears; both
-    look like a length mismatch and must not disconnect tracked clients.
+    Older firmware reports free/limit without the allocated list at all,
+    which looks like a length mismatch and must not disconnect tracked
+    clients.
     """
     handler = Mock()
     bluetooth_device.async_track_client(42, handler)
@@ -126,6 +126,12 @@ async def test_reconcile_isolates_raising_handler(
     boom.assert_called_once_with()
     ok.assert_called_once_with()
     assert "Error reconciling stale connection" in caplog.text
+    # The raising client was untracked before invocation, so a later update
+    # does not retry it and re-fire the warning plus traceback.
+    caplog.clear()
+    bluetooth_device.async_update_ble_connection_limits(3, 3, [])
+    boom.assert_called_once_with()
+    assert "Reconciling stale connection" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -106,6 +106,29 @@ async def test_reconcile_only_disconnects_missing_addresses(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_isolates_raising_handler(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A raising disconnect handler must not strand the other stale clients.
+
+    The handler ends in consumer supplied code; if one raises, the loop
+    logs it and still reconciles the remaining stale clients rather than
+    leaving them phantom until the next slot change.
+    """
+    boom = Mock(side_effect=RuntimeError("boom"))
+    ok = Mock()
+    bluetooth_device.async_track_client(42, boom)
+    bluetooth_device.async_track_client(43, ok)
+    with caplog.at_level(logging.WARNING):
+        bluetooth_device.async_update_ble_connection_limits(3, 3, [])
+    boom.assert_called_once_with()
+    ok.assert_called_once_with()
+    assert "Error reconciling stale connection" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_untrack_client_only_removes_matching_handler(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -69,6 +69,55 @@ async def test_wait_for_ble_connections_free_cancellation_cleans_up(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_skips_untrusted_allocated_list(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    An allocated list shorter than the used slot count is not trusted.
+
+    Older firmware reports free/limit without the allocated list, and an
+    in-flight connect consumes a slot before its address appears; both
+    look like a length mismatch and must not disconnect tracked clients.
+    """
+    handler = Mock()
+    bluetooth_device.async_track_client(42, handler)
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [])
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_only_disconnects_missing_addresses(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """Only the clients missing from the allocated list are disconnected."""
+    stale = Mock()
+    live = Mock()
+    bluetooth_device.async_track_client(42, stale)
+    bluetooth_device.async_track_client(43, live)
+    bluetooth_device.async_update_ble_connection_limits(2, 3, [43])
+    stale.assert_called_once_with()
+    live.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_untrack_client_only_removes_matching_handler(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """Untracking with a stale handler must not evict a newer client."""
+    old_handler = Mock()
+    new_handler = Mock()
+    bluetooth_device.async_track_client(42, new_handler)
+    bluetooth_device.async_untrack_client(42, old_handler)
+    bluetooth_device.async_update_ble_connection_limits(3, 3, [])
+    new_handler.assert_called_once_with()
+
+    bluetooth_device.async_untrack_client(42, new_handler)
+    new_handler.reset_mock()
+    bluetooth_device.async_update_ble_connection_limits(3, 3, [])
+    new_handler.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_wait_for_ble_connections_free_timer_after_result_does_not_raise(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:


### PR DESCRIPTION
When the proxy's connected=false notification is lost, for example on a congested link or an ESP side link loss that never produces one, nothing on a healthy API connection ever corrects the client state; is_connected stays true, the bleak disconnected callback never fires, and the consumer holds a dead client forever while the slot stays pinned. This is the phantom connection half of home-assistant/core#176516.

The proxy already broadcasts the authoritative set of connected addresses in every connections free update. The device now tracks each connected client by address and reconciles on every update, before subscribers are notified so the published snapshot and the clients' connected state stay consistent; any tracked client missing from the allocated list gets the normal BLE disconnect teardown, which fires the bleak callback and lets the consumer reconnect promptly. The list is only trusted when its length matches the used slot count, so older firmware that never sends the list is skipped. A reconcile logs a warning since it means the proxy and the host were out of sync, each handler is isolated so one raising consumer callback cannot strand the others, and a stale client is untracked before its handler runs so teardown is attempted exactly once.

Fixes #419
