### PR TITLE
fix: tear down session state on disconnect and stop in connection manager

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -152,7 +152,9 @@ caller:
 3. Fire every callback in `client_data.disconnect_callbacks` when the ESP
    disconnects, so `ESPHomeClient` instances drop their subscriptions.
    Iterate a snapshot of the set — each callback removes itself during
-   cleanup.
+   cleanup. Also set `client_data.bluetooth_device.available = False`
+   first, so the connector's `can_connect` gate stops offering the dead
+   proxy for new connection attempts.
 
 ```python
 import habluetooth
@@ -172,6 +174,7 @@ unregister_scanner = habluetooth.get_manager().async_register_scanner(
 )
 
 # Later, when the ESP disconnects:
+client_data.bluetooth_device.available = False
 for callback in list(client_data.disconnect_callbacks):
     callback()
 unregister_scanner()

--- a/examples/connect_scanner.py
+++ b/examples/connect_scanner.py
@@ -6,7 +6,7 @@ point — it owns the ``APIClient``, drives ``ReconnectLogic``, registers the
 scanner, and tears everything down for you. Reach for ``connect_scanner``
 only when you already manage the ``APIClient`` lifecycle yourself.
 
-``connect_scanner`` leaves three jobs to the caller, all of which this
+``connect_scanner`` leaves four jobs to the caller, all of which this
 example performs explicitly:
 
 1. Call ``client_data.scanner.async_setup()`` to attach the scanner to the
@@ -16,6 +16,8 @@ example performs explicitly:
 3. Fire every callback in ``client_data.disconnect_callbacks`` when the ESP
    disconnects. Iterate a snapshot of the set — each callback removes
    itself during cleanup.
+4. Set ``client_data.bluetooth_device.available = False`` first, so the
+   connector's ``can_connect`` gate stops offering the dead proxy.
 
 Replace ``DEVICE_ADDRESS`` / ``NOISE_PSK`` with your proxy's details before
 running. This talks to real hardware, so it cannot run in CI.
@@ -93,6 +95,10 @@ async def run() -> None:
         for device, adv in devices.values():
             print(f"{device} (rssi={adv.rssi})")
     finally:
+        # Responsibility 4: close the connect gate before firing callbacks
+        # so the dead proxy is not offered for new connection attempts.
+        if client_data is not None:
+            client_data.bluetooth_device.available = False
         # Responsibility 3: fire the disconnect callbacks (snapshot the set —
         # each callback removes itself). Guard each one so a single bad
         # callback cannot abort the rest of teardown, and keep un-register and

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -47,6 +47,9 @@ def connect_scanner(
     2. Calling ESPHomeClientData.disconnect_callbacks when the ESP is disconnected.
     3. Registering the scanner with the HA Bluetooth manager and also
        un-registering it when the ESP is disconnected.
+    4. Setting ESPHomeClientData.bluetooth_device.available to False when the
+       ESP is disconnected, before firing the callbacks, so the connector's
+       can_connect gate stops offering the dead proxy.
 
     The caller may choose to override ESPHomeClientData.disconnect_callbacks
     with its own set. If it does so, it must do so before calling

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -182,14 +182,29 @@ class APIConnectionManager:
         self._mark_unavailable()
         try:
             if self._reconnect_logic is not None:
-                await self._reconnect_logic.stop()
+                try:
+                    await self._reconnect_logic.stop()
+                except Exception:
+                    # A later shutdown step can replace this as the
+                    # propagating error; log so the root cause is never
+                    # lost. Cancellation passes through unlogged.
+                    _LOGGER.exception(
+                        "%s: Error stopping reconnect logic", self._address
+                    )
+                    raise
         finally:
             # Each shutdown step runs even if the previous one raised;
             # otherwise a failing reconnect stop would leave the API
             # client connected and a pending start() blocked forever.
             try:
                 if self._cli is not None:
-                    await self._cli.disconnect()
+                    try:
+                        await self._cli.disconnect()
+                    except Exception:
+                        _LOGGER.exception(
+                            "%s: Error disconnecting API client", self._address
+                        )
+                        raise
             finally:
                 if self._start_future is not None and not self._start_future.done():
                     self._start_future.cancel()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -183,12 +183,16 @@ class APIConnectionManager:
         try:
             if self._reconnect_logic is not None:
                 await self._reconnect_logic.stop()
-            if self._cli is not None:
-                await self._cli.disconnect()
-            if self._start_future is not None and not self._start_future.done():
-                self._start_future.cancel()
         finally:
-            # Same teardown as _on_disconnect so a stop() that never saw a
-            # disconnect callback, or whose shutdown awaits raised, still
-            # clears the session state.
-            self._teardown_session()
+            # Each shutdown step runs even if the previous one raised;
+            # otherwise a failing reconnect stop would leave the API
+            # client connected and a pending start() blocked forever.
+            try:
+                if self._cli is not None:
+                    await self._cli.disconnect()
+            finally:
+                if self._start_future is not None and not self._start_future.done():
+                    self._start_future.cancel()
+                # Same teardown as _on_disconnect so a stop() that never
+                # saw a disconnect callback still clears the session state.
+                self._teardown_session()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -13,6 +13,8 @@ from ._cancellation import is_spurious_cancellation
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from .backend.device import ESPHomeBluetoothDevice
+
 
 class ESPHomeStartAborted(Exception):
     """Raised when ``APIConnectionManager.start()`` is aborted by ``stop()``."""
@@ -44,6 +46,7 @@ class APIConnectionManager:
         self._unregister_scanner: Callable[[], None] | None = None
         self._unsetup_scanner: Callable[[], None] | None = None
         self._disconnect_callbacks: set[Callable[[], None]] | None = None
+        self._bluetooth_device: ESPHomeBluetoothDevice | None = None
         self._start_future: asyncio.Future[None] | None = None
 
     def _teardown_scanner(self) -> None:
@@ -61,15 +64,25 @@ class APIConnectionManager:
             if unregister is not None:
                 unregister()
 
-    async def _on_disconnect(self, expected_disconnect: bool) -> None:
-        """Handle the disconnection of the API client."""
-        if self._disconnect_callbacks is not None:
+    def _teardown_session(self) -> None:
+        """Tear down the per-session client state and the scanner."""
+        if self._bluetooth_device is not None:
+            # Mark the proxy unusable for the connector's can_connect gate.
+            self._bluetooth_device.available = False
+            self._bluetooth_device = None
+        if (disconnect_callbacks := self._disconnect_callbacks) is not None:
+            self._disconnect_callbacks = None
             # Each callback discards itself from the set, so iterate a
             # snapshot to avoid "set changed size during iteration".
-            for callback in list(self._disconnect_callbacks):
+            for callback in list(disconnect_callbacks):
                 callback()
-            self._disconnect_callbacks = None
+            # Clear in place: clients hold a reference to this set object.
+            disconnect_callbacks.clear()
         self._teardown_scanner()
+
+    async def _on_disconnect(self, expected_disconnect: bool) -> None:
+        """Handle the disconnection of the API client."""
+        self._teardown_session()
 
     async def _on_connect(self) -> None:
         """Handle the connection of the API client."""
@@ -85,6 +98,7 @@ class APIConnectionManager:
             scanner
         )
         self._disconnect_callbacks = client_data.disconnect_callbacks
+        self._bluetooth_device = client_data.bluetooth_device
         if self._start_future is not None and not self._start_future.done():
             self._start_future.set_result(None)
 
@@ -149,4 +163,6 @@ class APIConnectionManager:
             await self._cli.disconnect()
         if self._start_future is not None and not self._start_future.done():
             self._start_future.cancel()
-        self._teardown_scanner()
+        # Same teardown as _on_disconnect so a stop() that never saw a
+        # disconnect callback still clears the session state.
+        self._teardown_session()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, TypedDict
 
 import habluetooth
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from .backend.device import ESPHomeBluetoothDevice
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ESPHomeStartAborted(Exception):
@@ -64,21 +67,38 @@ class APIConnectionManager:
             if unregister is not None:
                 unregister()
 
-    def _teardown_session(self) -> None:
-        """Tear down the per-session client state and the scanner."""
+    def _mark_unavailable(self) -> None:
+        """Close the connector's can_connect gate for this session's proxy."""
         if self._bluetooth_device is not None:
-            # Mark the proxy unusable for the connector's can_connect gate.
             self._bluetooth_device.available = False
             self._bluetooth_device = None
-        if (disconnect_callbacks := self._disconnect_callbacks) is not None:
-            self._disconnect_callbacks = None
-            # Each callback discards itself from the set, so iterate a
-            # snapshot to avoid "set changed size during iteration".
-            for callback in list(disconnect_callbacks):
-                callback()
-            # Clear in place: clients hold a reference to this set object.
-            disconnect_callbacks.clear()
-        self._teardown_scanner()
+
+    def _teardown_session(self) -> None:
+        """Tear down the per-session client state and the scanner."""
+        self._mark_unavailable()
+        try:
+            if (disconnect_callbacks := self._disconnect_callbacks) is not None:
+                self._disconnect_callbacks = None
+                try:
+                    # Each callback discards itself from the set, so iterate
+                    # a snapshot to avoid "set changed size during
+                    # iteration". A callback ends in consumer supplied code;
+                    # one raising must not skip the other clients.
+                    for callback in list(disconnect_callbacks):
+                        try:
+                            callback()
+                        except Exception:  # pylint: disable=broad-except
+                            _LOGGER.exception(
+                                "%s: Error in disconnect callback", self._address
+                            )
+                finally:
+                    # Clear in place: clients hold a reference to this set
+                    # object.
+                    disconnect_callbacks.clear()
+        finally:
+            # The scanner unregister must run regardless; skipping it would
+            # leak the registration in habluetooth's manager.
+            self._teardown_scanner()
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Handle the disconnection of the API client."""
@@ -157,12 +177,18 @@ class APIConnectionManager:
 
     async def stop(self) -> None:
         """Stop the API connection."""
-        if self._reconnect_logic is not None:
-            await self._reconnect_logic.stop()
-        if self._cli is not None:
-            await self._cli.disconnect()
-        if self._start_future is not None and not self._start_future.done():
-            self._start_future.cancel()
-        # Same teardown as _on_disconnect so a stop() that never saw a
-        # disconnect callback still clears the session state.
-        self._teardown_session()
+        # Close the connect gate first so no new connection attempts are
+        # offered this proxy while its API connection is being torn down.
+        self._mark_unavailable()
+        try:
+            if self._reconnect_logic is not None:
+                await self._reconnect_logic.stop()
+            if self._cli is not None:
+                await self._cli.disconnect()
+            if self._start_future is not None and not self._start_future.done():
+                self._start_future.cancel()
+        finally:
+            # Same teardown as _on_disconnect so a stop() that never saw a
+            # disconnect callback, or whose shutdown awaits raised, still
+            # clears the session state.
+            self._teardown_session()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -182,29 +182,23 @@ class APIConnectionManager:
         self._mark_unavailable()
         try:
             if self._reconnect_logic is not None:
-                try:
-                    await self._reconnect_logic.stop()
-                except Exception:
-                    # A later shutdown step can replace this as the
-                    # propagating error; log so the root cause is never
-                    # lost. Cancellation passes through unlogged.
-                    _LOGGER.exception(
-                        "%s: Error stopping reconnect logic", self._address
-                    )
-                    raise
+                await self._reconnect_logic.stop()
+        except Exception:
+            # A later shutdown step can replace this as the propagating
+            # error; log so the root cause is never lost. Cancellation
+            # passes through unlogged.
+            _LOGGER.exception("%s: Error stopping reconnect logic", self._address)
+            raise
         finally:
             # Each shutdown step runs even if the previous one raised;
             # otherwise a failing reconnect stop would leave the API
             # client connected and a pending start() blocked forever.
             try:
                 if self._cli is not None:
-                    try:
-                        await self._cli.disconnect()
-                    except Exception:
-                        _LOGGER.exception(
-                            "%s: Error disconnecting API client", self._address
-                        )
-                        raise
+                    await self._cli.disconnect()
+            except Exception:
+                _LOGGER.exception("%s: Error disconnecting API client", self._address)
+                raise
             finally:
                 if self._start_future is not None and not self._start_future.done():
                     self._start_future.cancel()

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Callable, Iterator
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -382,11 +383,72 @@ async def test_stop_tears_down_session_state(
 
     callback.assert_called_once_with()
     assert not callbacks
-    # ``cast`` re-widens attribute types mypy narrowed after the direct
-    # assignments above so the asserts are not flagged unreachable.
+    # ``cast`` re-widens the attribute type mypy narrowed after the direct
+    # assignment above so the assert is not flagged unreachable.
     assert cast("set[Callable[[], None]] | None", manager._disconnect_callbacks) is None
     assert bluetooth_device.available is False
-    assert cast("Mock | None", manager._bluetooth_device) is None
+    assert manager._bluetooth_device is None
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_isolates_raising_callback(
+    conn_manager: APIConnectionManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A raising disconnect callback must not skip the rest of the teardown.
+
+    Callbacks end in consumer supplied code; if one raises it is logged,
+    the other callbacks still fire, the shared set is still cleared, and
+    the scanner is still unregistered so nothing leaks in habluetooth.
+    """
+    boom = Mock(side_effect=RuntimeError("boom"))
+    ok = Mock()
+    callbacks: set[Callable[[], None]] = {boom, ok}
+    conn_manager._disconnect_callbacks = callbacks
+    unregister = Mock()
+    conn_manager._unregister_scanner = unregister
+
+    with caplog.at_level(logging.ERROR):
+        await conn_manager._on_disconnect(expected_disconnect=False)
+
+    boom.assert_called_once_with()
+    ok.assert_called_once_with()
+    assert not callbacks
+    unregister.assert_called_once_with()
+    assert "Error in disconnect callback" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_unavailable_first_and_tears_down_on_error(
+    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+) -> None:
+    """
+    ``stop()`` closes the connect gate up front and tears down on error.
+
+    The proxy must not be offered for new connections while its API
+    connection is being torn down, and the session teardown must run
+    even if a shutdown await raises.
+    """
+    manager, mock_reconnect_logic, _ = conn_manager_with_mocked_reconnect
+    bluetooth_device = Mock(available=True)
+    manager._bluetooth_device = bluetooth_device
+    unregister = Mock()
+    manager._unregister_scanner = unregister
+    seen_available: list[bool] = []
+
+    async def _stop_and_raise() -> None:
+        seen_available.append(bluetooth_device.available)
+        raise RuntimeError("stop boom")
+
+    mock_reconnect_logic.stop = AsyncMock(side_effect=_stop_and_raise)
+    with pytest.raises(RuntimeError, match="stop boom"):
+        await manager.stop()
+
+    # The gate was already closed when the first shutdown await ran.
+    assert seen_available == [False]
+    unregister.assert_called_once_with()
+    assert manager._bluetooth_device is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -402,9 +402,13 @@ async def test_on_disconnect_isolates_raising_callback(
     the other callbacks still fire, the shared set is still cleared, and
     the scanner is still unregistered so nothing leaks in habluetooth.
     """
-    boom = Mock(side_effect=RuntimeError("boom"))
+    boom_one = Mock(side_effect=RuntimeError("boom one"))
+    boom_two = Mock(side_effect=RuntimeError("boom two"))
     ok = Mock()
-    callbacks: set[Callable[[], None]] = {boom, ok}
+    # Two raising callbacks make the assertion order independent: with a
+    # whole-loop try/except regression the second raiser is never reached
+    # regardless of set iteration order.
+    callbacks: set[Callable[[], None]] = {boom_one, boom_two, ok}
     conn_manager._disconnect_callbacks = callbacks
     unregister = Mock()
     conn_manager._unregister_scanner = unregister
@@ -412,16 +416,24 @@ async def test_on_disconnect_isolates_raising_callback(
     with caplog.at_level(logging.ERROR):
         await conn_manager._on_disconnect(expected_disconnect=False)
 
-    boom.assert_called_once_with()
+    boom_one.assert_called_once_with()
+    boom_two.assert_called_once_with()
     ok.assert_called_once_with()
     assert not callbacks
     unregister.assert_called_once_with()
-    assert "Error in disconnect callback" in caplog.text
+    error_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+        and "Error in disconnect callback" in record.message
+    ]
+    assert len(error_records) == 2
 
 
 @pytest.mark.asyncio
 async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     ``stop()`` closes the connect gate up front and tears down on error.
@@ -442,8 +454,15 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
         raise RuntimeError("stop boom")
 
     mock_reconnect_logic.stop = AsyncMock(side_effect=_stop_and_raise)
-    with pytest.raises(RuntimeError, match="stop boom"):
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(RuntimeError, match="stop boom"),
+    ):
         await manager.stop()
+
+    # The root cause is logged even if a later step were to replace it as
+    # the propagating error.
+    assert "Error stopping reconnect logic" in caplog.text
 
     # The gate was already closed when the first shutdown await ran.
     assert seen_available == [False]
@@ -458,6 +477,7 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
 @pytest.mark.asyncio
 async def test_stop_cancels_pending_start_when_disconnect_raises(
     config: ESPHomeDeviceConfig,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A raising client disconnect must not leave a pending start() blocked."""
     manager = APIConnectionManager(config)
@@ -469,11 +489,15 @@ async def test_stop_cancels_pending_start_when_disconnect_raises(
     unregister = Mock()
     manager._unregister_scanner = unregister
 
-    with pytest.raises(RuntimeError, match="disconnect boom"):
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(RuntimeError, match="disconnect boom"),
+    ):
         await manager.stop()
 
     assert manager._start_future.cancelled()
     unregister.assert_called_once_with()
+    assert "Error disconnecting API client" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -430,7 +430,7 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     connection is being torn down, and the session teardown must run
     even if a shutdown await raises.
     """
-    manager, mock_reconnect_logic, _ = conn_manager_with_mocked_reconnect
+    manager, mock_reconnect_logic, mock_disconnect = conn_manager_with_mocked_reconnect
     bluetooth_device = Mock(available=True)
     manager._bluetooth_device = bluetooth_device
     unregister = Mock()
@@ -448,7 +448,32 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     # The gate was already closed when the first shutdown await ran.
     assert seen_available == [False]
     unregister.assert_called_once_with()
-    assert manager._bluetooth_device is None
+    # ``cast`` re-widens the attribute type mypy narrowed after the direct
+    # assignment above so the following statements are not unreachable.
+    assert cast("Mock | None", manager._bluetooth_device) is None
+    # The later shutdown steps still ran despite the earlier raise.
+    mock_disconnect.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending_start_when_disconnect_raises(
+    config: ESPHomeDeviceConfig,
+) -> None:
+    """A raising client disconnect must not leave a pending start() blocked."""
+    manager = APIConnectionManager(config)
+    manager._cli = Mock()
+    manager._cli.disconnect = AsyncMock(side_effect=RuntimeError("disconnect boom"))
+    manager._reconnect_logic = Mock()
+    manager._reconnect_logic.stop = AsyncMock()
+    manager._start_future = asyncio.get_running_loop().create_future()
+    unregister = Mock()
+    manager._unregister_scanner = unregister
+
+    with pytest.raises(RuntimeError, match="disconnect boom"):
+        await manager.stop()
+
+    assert manager._start_future.cancelled()
+    unregister.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -207,6 +207,7 @@ async def test_on_connect_registers_scanner_and_resolves_start(
     )
     assert conn_manager._unregister_scanner is unregister_scanner
     assert conn_manager._disconnect_callbacks is mock_client_data.disconnect_callbacks
+    assert conn_manager._bluetooth_device is mock_client_data.bluetooth_device
     assert conn_manager._start_future is not None
     assert conn_manager._start_future.done()
     assert conn_manager._start_future.result() is None
@@ -279,13 +280,41 @@ async def test_on_disconnect_fires_client_data_disconnect_callbacks(
     """
     cb_one = Mock()
     cb_two = Mock()
-    conn_manager._disconnect_callbacks = {cb_one, cb_two}
+    callbacks: set[Callable[[], None]] = {cb_one, cb_two}
+    conn_manager._disconnect_callbacks = callbacks
 
     await conn_manager._on_disconnect(expected_disconnect=False)
 
     cb_one.assert_called_once_with()
     cb_two.assert_called_once_with()
-    assert conn_manager._disconnect_callbacks is None
+    # ``cast`` re-widens the attribute type mypy narrowed after the
+    # assignment above so the assert is not flagged unreachable.
+    assert (
+        cast("set[Callable[[], None]] | None", conn_manager._disconnect_callbacks)
+        is None
+    )
+    # Cleared in place as well: clients hold a reference to the set, and
+    # a stale entry would keep its client alive in an orphaned set.
+    assert not callbacks
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_marks_bluetooth_device_unavailable(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """
+    ``_on_disconnect`` flags the bluetooth device as unavailable.
+
+    The connector's ``can_connect`` gate reads ``available``; leaving it
+    set would keep offering a proxy whose API connection is gone.
+    """
+    bluetooth_device = Mock(available=True)
+    conn_manager._bluetooth_device = bluetooth_device
+
+    await conn_manager._on_disconnect(expected_disconnect=False)
+
+    assert bluetooth_device.available is False
+    assert conn_manager._bluetooth_device is None
 
 
 @pytest.mark.asyncio
@@ -329,6 +358,54 @@ async def test_stop_unregisters_scanner_if_registered(
     # ``cast`` re-widens the attribute type that mypy narrowed to ``Mock``
     # after the earlier assignment so ``is None`` is not flagged unreachable.
     assert cast(Callable[[], None] | None, manager._unregister_scanner) is None
+
+
+@pytest.mark.asyncio
+async def test_stop_tears_down_session_state(
+    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+) -> None:
+    """
+    ``stop()`` runs the same session teardown as ``_on_disconnect``.
+
+    A stop that never saw a disconnect callback must still fire the
+    client disconnect callbacks, clear the shared set in place, and
+    mark the bluetooth device unavailable.
+    """
+    manager, _, _ = conn_manager_with_mocked_reconnect
+    callback = Mock()
+    callbacks: set[Callable[[], None]] = {callback}
+    manager._disconnect_callbacks = callbacks
+    bluetooth_device = Mock(available=True)
+    manager._bluetooth_device = bluetooth_device
+
+    await manager.stop()
+
+    callback.assert_called_once_with()
+    assert not callbacks
+    # ``cast`` re-widens attribute types mypy narrowed after the direct
+    # assignments above so the asserts are not flagged unreachable.
+    assert cast("set[Callable[[], None]] | None", manager._disconnect_callbacks) is None
+    assert bluetooth_device.available is False
+    assert cast("Mock | None", manager._bluetooth_device) is None
+
+
+@pytest.mark.asyncio
+async def test_stop_after_disconnect_does_not_refire_callbacks(
+    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+) -> None:
+    """A ``stop()`` following ``_on_disconnect`` must not refire callbacks."""
+    manager, _, _ = conn_manager_with_mocked_reconnect
+    callback = Mock()
+    manager._disconnect_callbacks = {callback}
+    bluetooth_device = Mock(available=True)
+    manager._bluetooth_device = bluetooth_device
+
+    await manager._on_disconnect(expected_disconnect=True)
+    callback.assert_called_once_with()
+    assert bluetooth_device.available is False
+
+    await manager.stop()
+    callback.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The standalone connection manager left stale session state behind on disconnect; the bluetooth device stayed available so the connector's can_connect gate kept offering a proxy whose API connection was gone, and the disconnect callbacks set was dropped by reference without being cleared, so a stale entry could keep its client alive in a set nobody iterates again. This mirrors what Home Assistant's entry_data already does on disconnect.

Session teardown now lives in one helper shared by the disconnect callback and stop(); each consumer supplied callback is isolated so one raising cannot skip the others, and the in place clear plus the scanner unregister run in finally blocks so nothing can skip them. stop() closes the connect gate before its shutdown awaits, runs each shutdown step in its own finally so a failing reconnect stop still disconnects the API client and a failing disconnect still cancels a pending start(), and logs each step's failure so a later step cannot mask the root cause. The manual connect_scanner recipe in the docs now flips available as well.

Related to home-assistant/core#176516.
