### PR TITLE
fix!: fail pending slot waiters when the proxy becomes unavailable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,8 +35,9 @@ Bluetooth proxy: hand it a device config, `await start()`, and it owns the
 `connect_scanner` is for advanced callers that manage their own `APIClient`
 lifecycle. It wires an `aioesphomeapi.APIClient` to an `ESPHomeScanner` +
 `ESPHomeClient` and returns the assembled `ESPHomeClientData`, but leaves the
-three caller responsibilities (scanner setup, disconnect callbacks, manager
-registration) up to you — read the docstring carefully before reaching for it.
+four caller responsibilities (scanner setup, marking the device unavailable
+on disconnect, disconnect callbacks, manager registration) up to you — read
+the docstring carefully before reaching for it.
 
 ```{eval-rst}
 .. autofunction:: bleak_esphome.connect_scanner

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,5 +40,9 @@ on disconnect, disconnect callbacks, manager registration) up to you — read
 the docstring carefully before reaching for it.
 
 ```{eval-rst}
+.. automethod:: bleak_esphome.backend.device.ESPHomeBluetoothDevice.async_set_unavailable
+```
+
+```{eval-rst}
 .. autofunction:: bleak_esphome.connect_scanner
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,10 @@ names exported from the top-level package. For how these pieces fit together,
 see [the architecture overview](architecture.md); for task-oriented examples,
 see [usage](usage.md).
 
-Everything documented here is re-exported from `bleak_esphome` directly, so the
-import you write in application code is, for example:
+Everything documented here is re-exported from `bleak_esphome` directly (the
+one exception, `async_set_unavailable`, is reached through
+`client_data.bluetooth_device`), so the import you write in application code
+is, for example:
 
 ```python
 from bleak_esphome import APIConnectionManager, ESPHomeDeviceConfig
@@ -40,9 +42,12 @@ on disconnect, disconnect callbacks, manager registration) up to you — read
 the docstring carefully before reaching for it.
 
 ```{eval-rst}
-.. automethod:: bleak_esphome.backend.device.ESPHomeBluetoothDevice.async_set_unavailable
+.. autofunction:: bleak_esphome.connect_scanner
 ```
 
+`async_set_unavailable` lives on the `ESPHomeBluetoothDevice` returned in
+`client_data.bluetooth_device`; it is not a top-level export.
+
 ```{eval-rst}
-.. autofunction:: bleak_esphome.connect_scanner
+.. automethod:: bleak_esphome.backend.device.ESPHomeBluetoothDevice.async_set_unavailable
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,6 +131,15 @@ at that layer rather than in this library: reduce Wi-Fi/BLE contention on the
 proxy's channel, improve RF line-of-sight to the peripheral, or reduce how
 many devices a single proxy is asked to hold at once.
 
+## `Proxy became unavailable while waiting for a free BLE connection slot`
+
+A connect attempt was waiting for a free connection slot on a proxy whose
+API connection dropped. Instead of parking for the full timeout on a proxy
+that is provably gone, the waiter fails immediately with this message so
+the retry logic can move to another proxy. The fail fast disarms as soon
+as the proxy reports slot state again, or when a caller reusing the
+device marks it available on reconnect.
+
 ## Can I pin a BLE device to a specific proxy?
 
 No. `bleak-esphome` does not decide which proxy connects to which device. It

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,6 +184,12 @@ If you also want to override which `disconnect_callbacks` set is used —
 for example, to share one set across several scanners — reassign
 `client_data.disconnect_callbacks` **before** calling `async_setup()`.
 
+When the ESP disconnects, also call
+`client_data.bluetooth_device.async_set_unavailable()`. It closes the
+connector's `can_connect` gate and immediately fails any caller waiting
+for a free connection slot, so connect attempts stop parking their full
+timeout on a proxy that is already gone.
+
 ## Scanning Modes
 
 The proxy can scan in one of two firmware modes, and `habluetooth` adds a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,13 +149,13 @@ caller:
    running loop.
 2. Register the scanner with the host-side Bluetooth manager (and
    un-register it when the ESP disconnects).
-3. Fire every callback in `client_data.disconnect_callbacks` when the ESP
-   disconnects, so `ESPHomeClient` instances drop their subscriptions.
-   Iterate a snapshot of the set — each callback removes itself during
-   cleanup.
-4. Call `client_data.bluetooth_device.async_set_unavailable()` first, so
-   the connector's `can_connect` gate stops offering the dead proxy and
-   callers waiting for a free connection slot fail fast.
+3. Call `client_data.bluetooth_device.async_set_unavailable()` first when
+   the ESP disconnects, so the connector's `can_connect` gate stops
+   offering the dead proxy and callers waiting for a free connection
+   slot fail fast.
+4. Fire every callback in `client_data.disconnect_callbacks`, so
+   `ESPHomeClient` instances drop their subscriptions. Iterate a
+   snapshot of the set — each callback removes itself during cleanup.
 
 ```python
 import habluetooth

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -142,7 +142,7 @@ reconnect / discovery machinery).
 `connect_scanner(cli, device_info, available)` wires an
 `aioesphomeapi.APIClient` to an `ESPHomeScanner` + `ESPHomeClient` and
 subscribes to the proxy's advertisement, scanner-state, and connection-slot
-streams. It returns an `ESPHomeClientData` and leaves three jobs to the
+streams. It returns an `ESPHomeClientData` and leaves four jobs to the
 caller:
 
 1. Call `client_data.scanner.async_setup()` to attach the scanner to the
@@ -152,9 +152,10 @@ caller:
 3. Fire every callback in `client_data.disconnect_callbacks` when the ESP
    disconnects, so `ESPHomeClient` instances drop their subscriptions.
    Iterate a snapshot of the set — each callback removes itself during
-   cleanup. Also set `client_data.bluetooth_device.available = False`
-   first, so the connector's `can_connect` gate stops offering the dead
-   proxy for new connection attempts.
+   cleanup.
+4. Call `client_data.bluetooth_device.async_set_unavailable()` first, so
+   the connector's `can_connect` gate stops offering the dead proxy and
+   callers waiting for a free connection slot fail fast.
 
 ```python
 import habluetooth
@@ -174,7 +175,7 @@ unregister_scanner = habluetooth.get_manager().async_register_scanner(
 )
 
 # Later, when the ESP disconnects:
-client_data.bluetooth_device.available = False
+client_data.bluetooth_device.async_set_unavailable()
 for callback in list(client_data.disconnect_callbacks):
     callback()
 unregister_scanner()
@@ -183,12 +184,6 @@ unregister_scanner()
 If you also want to override which `disconnect_callbacks` set is used —
 for example, to share one set across several scanners — reassign
 `client_data.disconnect_callbacks` **before** calling `async_setup()`.
-
-When the ESP disconnects, also call
-`client_data.bluetooth_device.async_set_unavailable()`. It closes the
-connector's `can_connect` gate and immediately fails any caller waiting
-for a free connection slot, so connect attempts stop parking their full
-timeout on a proxy that is already gone.
 
 ## Scanning Modes
 

--- a/examples/connect_scanner.py
+++ b/examples/connect_scanner.py
@@ -13,12 +13,12 @@ example performs explicitly:
    running loop.
 2. Register the scanner with the host-side Bluetooth manager (and
    un-register it when the ESP disconnects).
-3. Fire every callback in ``client_data.disconnect_callbacks`` when the ESP
-   disconnects. Iterate a snapshot of the set — each callback removes
-   itself during cleanup.
-4. Call ``client_data.bluetooth_device.async_set_unavailable()`` first,
-   so the connector's ``can_connect`` gate stops offering the dead proxy
-   and callers waiting for a free connection slot fail fast.
+3. Call ``client_data.bluetooth_device.async_set_unavailable()`` when the
+   ESP disconnects, so the connector's ``can_connect`` gate stops offering
+   the dead proxy and callers waiting for a free connection slot fail
+   fast.
+4. Fire every callback in ``client_data.disconnect_callbacks``. Iterate a
+   snapshot of the set — each callback removes itself during cleanup.
 
 Replace ``DEVICE_ADDRESS`` / ``NOISE_PSK`` with your proxy's details before
 running. This talks to real hardware, so it cannot run in CI.
@@ -96,11 +96,12 @@ async def run() -> None:
         for device, adv in devices.values():
             print(f"{device} (rssi={adv.rssi})")
     finally:
-        # Responsibility 4: close the connect gate before firing callbacks
-        # so the dead proxy is not offered for new connection attempts.
+        # Responsibility 3: close the connect gate and fail slot waiters
+        # before firing callbacks, so the dead proxy is not offered for
+        # new connection attempts.
         if client_data is not None:
             client_data.bluetooth_device.async_set_unavailable()
-        # Responsibility 3: fire the disconnect callbacks (snapshot the set —
+        # Responsibility 4: fire the disconnect callbacks (snapshot the set —
         # each callback removes itself). Guard each one so a single bad
         # callback cannot abort the rest of teardown, and keep un-register and
         # disconnect in their own guarded steps so they always run.

--- a/examples/connect_scanner.py
+++ b/examples/connect_scanner.py
@@ -16,8 +16,9 @@ example performs explicitly:
 3. Fire every callback in ``client_data.disconnect_callbacks`` when the ESP
    disconnects. Iterate a snapshot of the set — each callback removes
    itself during cleanup.
-4. Set ``client_data.bluetooth_device.available = False`` first, so the
-   connector's ``can_connect`` gate stops offering the dead proxy.
+4. Call ``client_data.bluetooth_device.async_set_unavailable()`` first,
+   so the connector's ``can_connect`` gate stops offering the dead proxy
+   and callers waiting for a free connection slot fail fast.
 
 Replace ``DEVICE_ADDRESS`` / ``NOISE_PSK`` with your proxy's details before
 running. This talks to real hardware, so it cannot run in CI.
@@ -98,7 +99,7 @@ async def run() -> None:
         # Responsibility 4: close the connect gate before firing callbacks
         # so the dead proxy is not offered for new connection attempts.
         if client_data is not None:
-            client_data.bluetooth_device.available = False
+            client_data.bluetooth_device.async_set_unavailable()
         # Responsibility 3: fire the disconnect callbacks (snapshot the set —
         # each callback removes itself). Guard each one so a single bad
         # callback cannot abort the rest of teardown, and keep un-register and

--- a/examples/connect_scanner.py
+++ b/examples/connect_scanner.py
@@ -100,6 +100,7 @@ async def run() -> None:
         # before firing callbacks, so the dead proxy is not offered for
         # new connection attempts.
         if client_data is not None:
+            # Never raises, so no guard is needed here.
             client_data.bluetooth_device.async_set_unavailable()
         # Responsibility 4: fire the disconnect callbacks (snapshot the set —
         # each callback removes itself). Guard each one so a single bad

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -545,9 +545,17 @@ class ESPHomeClient(BaseBleakClient):
             await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
-        # Settle only; a teardown path has nothing to fail over to.
-        with contextlib.suppress(TimeoutError):
+        try:
             await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+        except TimeoutError as ex:
+            # Settle only; a teardown path has nothing to fail over to.
+            # Logged since a slot that never frees is the unreclaimed
+            # allocation symptom.
+            _LOGGER.debug(
+                "%s: Slot did not settle after disconnect: %s",
+                self._description,
+                ex,
+            )
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -310,7 +310,7 @@ class ESPHomeClient(BaseBleakClient):
         self._async_disconnected_cleanup()
         return False
 
-    async def _settle_slot_after_failure(self, context: str, timeout: float) -> None:
+    async def _settle_slot(self, context: str, timeout: float) -> None:
         """
         Wait for the freed slot to settle after a failure or disconnect.
 
@@ -510,9 +510,7 @@ class ESPHomeClient(BaseBleakClient):
             # Settle outside the ``connecting()`` pause; cancels and
             # signals bypass this handler and are never stalled behind it.
             if settle_needed:
-                await self._settle_slot_after_failure(
-                    "failed connect", CONNECT_FREE_SLOT_TIMEOUT
-                )
+                await self._settle_slot("failed connect", CONNECT_FREE_SLOT_TIMEOUT)
             raise
 
         try:
@@ -525,7 +523,7 @@ class ESPHomeClient(BaseBleakClient):
             # Release, then settle before the retry; never mask the
             # original error.
             if self._abandon_connect_attempt():
-                await self._settle_slot_after_failure(
+                await self._settle_slot(
                     "failed connect setup", CONNECT_FREE_SLOT_TIMEOUT
                 )
             raise
@@ -551,7 +549,7 @@ class ESPHomeClient(BaseBleakClient):
         finally:
             self._async_ble_device_disconnected()
         # Settle only; a teardown path has nothing to fail over to.
-        await self._settle_slot_after_failure("disconnect", DISCONNECT_TIMEOUT)
+        await self._settle_slot("disconnect", DISCONNECT_TIMEOUT)
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -310,7 +310,9 @@ class ESPHomeClient(BaseBleakClient):
         self._async_disconnected_cleanup()
         return False
 
-    async def _settle_slot_after_failure(self, context: str) -> None:
+    async def _settle_slot_after_failure(
+        self, context: str, timeout: float = CONNECT_FREE_SLOT_TIMEOUT
+    ) -> None:
         """
         Wait for the freed slot to settle after a failed attempt.
 
@@ -320,7 +322,7 @@ class ESPHomeClient(BaseBleakClient):
         free slot on the proxy returns immediately.
         """
         try:
-            await self._wait_for_free_connection_slot(CONNECT_FREE_SLOT_TIMEOUT)
+            await self._wait_for_free_connection_slot(timeout)
         except TimeoutError as settle_error:
             # The expected shape on a slow or saturated proxy.
             _LOGGER.debug(
@@ -545,17 +547,8 @@ class ESPHomeClient(BaseBleakClient):
             await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
-        try:
-            await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
-        except TimeoutError as ex:
-            # Settle only; a teardown path has nothing to fail over to.
-            # Logged since a slot that never frees is the unreclaimed
-            # allocation symptom.
-            _LOGGER.debug(
-                "%s: Slot did not settle after disconnect: %s",
-                self._description,
-                ex,
-            )
+        # Settle only; a teardown path has nothing to fail over to.
+        await self._settle_slot_after_failure("disconnect", DISCONNECT_TIMEOUT)
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -310,16 +310,15 @@ class ESPHomeClient(BaseBleakClient):
         self._async_disconnected_cleanup()
         return False
 
-    async def _settle_slot_after_failure(
-        self, context: str, timeout: float = CONNECT_FREE_SLOT_TIMEOUT
-    ) -> None:
+    async def _settle_slot_after_failure(self, context: str, timeout: float) -> None:
         """
-        Wait for the freed slot to settle after a failed attempt.
+        Wait for the freed slot to settle after a failure or disconnect.
 
-        Capped to the same window as the next attempt's entry gate in
-        ``connect()``; a settle failure is logged, never raised, so it
-        cannot mask the original error. Slot level, not link level: any
-        free slot on the proxy returns immediately.
+        Callers pass the window that matters to them: the connect gate
+        window for retries, ``DISCONNECT_TIMEOUT`` for teardown. A
+        settle failure is logged, never raised, so it cannot mask the
+        original outcome. Slot level, not link level: any free slot on
+        the proxy returns immediately.
         """
         try:
             await self._wait_for_free_connection_slot(timeout)
@@ -511,7 +510,9 @@ class ESPHomeClient(BaseBleakClient):
             # Settle outside the ``connecting()`` pause; cancels and
             # signals bypass this handler and are never stalled behind it.
             if settle_needed:
-                await self._settle_slot_after_failure("failed connect")
+                await self._settle_slot_after_failure(
+                    "failed connect", CONNECT_FREE_SLOT_TIMEOUT
+                )
             raise
 
         try:
@@ -524,7 +525,9 @@ class ESPHomeClient(BaseBleakClient):
             # Release, then settle before the retry; never mask the
             # original error.
             if self._abandon_connect_attempt():
-                await self._settle_slot_after_failure("failed connect setup")
+                await self._settle_slot_after_failure(
+                    "failed connect setup", CONNECT_FREE_SLOT_TIMEOUT
+                )
             raise
         except BaseException:
             # No settle on cancels and signals; still release.

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -545,7 +545,9 @@ class ESPHomeClient(BaseBleakClient):
             await self._client.bluetooth_device_disconnect(self._address_as_int)
         finally:
             self._async_ble_device_disconnected()
-        await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
+        # Settle only; a teardown path has nothing to fail over to.
+        with contextlib.suppress(TimeoutError):
+            await self._wait_for_free_connection_slot(DISCONNECT_TIMEOUT)
 
     async def _wait_for_free_connection_slot(self, timeout: float) -> None:
         """Wait for a free connection slot."""

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -91,45 +91,33 @@ class ESPHomeBluetoothDevice:
         """
         Mark the proxy unavailable and fail pending slot waiters.
 
-        A caller parked in ``wait_for_ble_connections_free`` would
-        otherwise sit out its full timeout on a proxy already known to be
-        gone; failing fast lets it retry against another proxy. The latch
-        clears when the proxy reports slot state again via
-        ``async_update_ble_connection_limits``; ``available`` is not
-        restored by that, so a caller reusing this device must set it
-        back to ``True`` on reconnect, which also disarms the fail fast
-        immediately; the free count stays zero until the proxy's first
-        slot report, so the new session never trusts the dead session's
-        count. This method never raises, so teardown paths can call it
-        without guards.
+        Failing fast lets a parked waiter retry against another proxy
+        instead of sitting out its full timeout. The latch clears on the
+        next slot report; ``available`` is not restored by that, so a
+        reusing caller must set it back to ``True`` on reconnect, which
+        disarms the fail fast immediately. The free count stays zero
+        until the first slot report. This method never raises, so
+        teardown paths can call it without guards.
         """
         self.available = False
-        # Distinct from ``available``, which defaults to False before the
-        # first connect; only an explicit unavailability marks the proxy
-        # dead for the wait entry guard below.
+        # Distinct from ``available``: only an explicit unavailability
+        # arms the wait entry guard.
         self._unavailable = True
-        # The dead session's allocated list must not survive into a
-        # reused device; stale addresses feeding scanner.get_allocations
-        # are the cross proxy duplicate symptom this work exists to kill.
-        # ``free`` is zeroed with it: a proxy whose API connection is
-        # gone provably has no usable slots, and a reusing caller that
-        # restores ``available`` must not have connects gated (or slot
-        # waits satisfied) by the dead session's count. ``limit`` keeps
-        # the last reported capacity for allocation consumers.
+        # Clear the dead session's allocated list and free count so a
+        # reused device cannot serve stale state; ``limit`` keeps the
+        # last reported capacity.
         had_state = bool(self.ble_allocations) or bool(self.ble_connections_free)
         self.ble_allocations = []
         self.ble_connections_free = 0
         message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
-            # Skip futures already done (a cancelled waiter leaves its
-            # future in the set until its finally runs).
+            # A cancelled waiter can leave a done future in the set.
             if not fut.done():
                 fut.set_exception(TimeoutError(message))
         self._ble_connection_free_futures.clear()
         if had_state and (connection_slots_callback := self._connection_slots_callback):
-            # Push the cleared snapshot after the primary contract is
-            # done so a raising subscriber cannot strand the waiters;
-            # guarded because it ends in consumer supplied code.
+            # Push after the waiters are failed; guarded since it ends
+            # in consumer supplied code.
             try:
                 connection_slots_callback(
                     Allocations(
@@ -312,10 +300,8 @@ class ESPHomeBluetoothDevice:
 
         """
         if self._unavailable and not self.available:
-            # Fail fast for waiters arriving after the proxy went away;
-            # they would otherwise park the full timeout on a proxy that
-            # is provably dead. A caller that restored ``available`` on
-            # reconnect disarms this even before the first slot report.
+            # Fail fast instead of parking the full timeout on a proxy
+            # that is provably dead.
             raise TimeoutError(self._unavailable_message())
         if self.ble_connections_free > 0:
             return self.ble_connections_free

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -78,6 +78,25 @@ class ESPHomeBluetoothDevice:
         """
         if self._tracked_clients.get(address) == on_ble_disconnected:
             del self._tracked_clients[address]
+    def async_set_unavailable(self) -> None:
+        """
+        Mark the proxy unavailable and fail pending slot waiters.
+
+        A caller parked in ``wait_for_ble_connections_free`` would
+        otherwise sit out its full timeout on a proxy already known to be
+        gone; failing fast lets it retry against another proxy.
+        """
+        self.available = False
+        message = (
+            f"{self.name} [{self.mac_address}]: Proxy disconnected "
+            "while waiting for a free BLE connection slot"
+        )
+        for fut in self._ble_connection_free_futures:
+            # Skip futures already done (a cancelled waiter leaves its
+            # future in the set until its finally runs).
+            if not fut.done():
+                fut.set_exception(TimeoutError(message))
+        self._ble_connection_free_futures.clear()
 
     def async_update_ble_connection_limits(
         self, free: int, limit: int, allocated: list[int]
@@ -235,7 +254,9 @@ class ESPHomeBluetoothDevice:
         report at least one free slot via ``async_update_ble_connection_limits``.
 
         Raises:
-            TimeoutError: if no slot becomes free within ``timeout`` seconds.
+            TimeoutError: if no slot becomes free within ``timeout``
+                seconds, or immediately if the proxy becomes unavailable
+                while waiting (see ``async_set_unavailable``).
 
         """
         if self.ble_connections_free > 0:

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -97,7 +97,8 @@ class ESPHomeBluetoothDevice:
         clears when the proxy reports slot state again via
         ``async_update_ble_connection_limits``; ``available`` is not
         restored by that, so a caller reusing this device must set it
-        back to ``True`` on reconnect.
+        back to ``True`` on reconnect, which also disarms the fail fast
+        immediately.
         """
         self.available = False
         # Distinct from ``available``, which defaults to False before the
@@ -277,10 +278,11 @@ class ESPHomeBluetoothDevice:
                 while waiting (see ``async_set_unavailable``).
 
         """
-        if self._unavailable:
+        if self._unavailable and not self.available:
             # Fail fast for waiters arriving after the proxy went away;
             # they would otherwise park the full timeout on a proxy that
-            # is provably dead.
+            # is provably dead. A caller that restored ``available`` on
+            # reconnect disarms this even before the first slot report.
             raise TimeoutError(self._unavailable_message())
         if self.ble_connections_free > 0:
             return self.ble_connections_free

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -95,7 +95,9 @@ class ESPHomeBluetoothDevice:
         otherwise sit out its full timeout on a proxy already known to be
         gone; failing fast lets it retry against another proxy. The latch
         clears when the proxy reports slot state again via
-        ``async_update_ble_connection_limits``.
+        ``async_update_ble_connection_limits``; ``available`` is not
+        restored by that, so a caller reusing this device must set it
+        back to ``True`` on reconnect.
         """
         self.available = False
         # Distinct from ``available``, which defaults to False before the

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -98,7 +98,8 @@ class ESPHomeBluetoothDevice:
         ``async_update_ble_connection_limits``; ``available`` is not
         restored by that, so a caller reusing this device must set it
         back to ``True`` on reconnect, which also disarms the fail fast
-        immediately.
+        immediately. This method never raises, so teardown paths can
+        call it without guards.
         """
         self.available = False
         # Distinct from ``available``, which defaults to False before the
@@ -108,24 +109,12 @@ class ESPHomeBluetoothDevice:
         # The dead session's allocated list must not survive into a
         # reused device; stale addresses feeding scanner.get_allocations
         # are the cross proxy duplicate symptom this work exists to kill.
-        # The free and limit counters stay, zeroing free would turn the
-        # public disconnect() slot wait into an immediate TimeoutError.
+        # The free and limit counters keep the last reported state:
+        # inventing counter values would lie to allocation consumers, and
+        # waits on an unavailable device are governed by the entry guard,
+        # not the free count.
         had_allocations = bool(self.ble_allocations)
         self.ble_allocations = []
-        if had_allocations and (
-            connection_slots_callback := self._connection_slots_callback
-        ):
-            # Push the cleared snapshot so the subscriber's stored copy
-            # (habluetooth's allocations map) does not keep rendering the
-            # dead session's addresses either.
-            connection_slots_callback(
-                Allocations(
-                    self.mac_address,
-                    self.ble_connections_limit,
-                    self.ble_connections_free,
-                    [],
-                )
-            )
         message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
             # Skip futures already done (a cancelled waiter leaves its
@@ -133,6 +122,27 @@ class ESPHomeBluetoothDevice:
             if not fut.done():
                 fut.set_exception(TimeoutError(message))
         self._ble_connection_free_futures.clear()
+        if had_allocations and (
+            connection_slots_callback := self._connection_slots_callback
+        ):
+            # Push the cleared snapshot after the primary contract is
+            # done so a raising subscriber cannot strand the waiters;
+            # guarded because it ends in consumer supplied code.
+            try:
+                connection_slots_callback(
+                    Allocations(
+                        self.mac_address,
+                        self.ble_connections_limit,
+                        self.ble_connections_free,
+                        [],
+                    )
+                )
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    "%s [%s]: Error pushing cleared allocations",
+                    self.name,
+                    self.mac_address,
+                )
 
     def async_update_ble_connection_limits(
         self, free: int, limit: int, allocated: list[int]

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -116,9 +116,12 @@ class ESPHomeBluetoothDevice:
                 if not fut.done():
                     fut.set_exception(TimeoutError(message))
             futures.clear()
-        if had_state:
-            # Push after the waiters are failed.
-            self._async_publish_allocations(self.ble_connections_limit, 0, [])
+        if had_state and not self._async_publish_allocations(
+            self.ble_connections_limit, 0, []
+        ):
+            # Re-arm the forced push so the next slot report corrects
+            # the subscriber's stale snapshot.
+            self._called_callback = False
 
     def _async_publish_allocations(
         self, limit: int, free: int, allocated: list[str]

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -93,7 +93,9 @@ class ESPHomeBluetoothDevice:
 
         A caller parked in ``wait_for_ble_connections_free`` would
         otherwise sit out its full timeout on a proxy already known to be
-        gone; failing fast lets it retry against another proxy.
+        gone; failing fast lets it retry against another proxy. The latch
+        clears when the proxy reports slot state again via
+        ``async_update_ble_connection_limits``.
         """
         self.available = False
         # Distinct from ``available``, which defaults to False before the
@@ -112,6 +114,10 @@ class ESPHomeBluetoothDevice:
         self, free: int, limit: int, allocated: list[int]
     ) -> None:
         """Update the BLE connection limits."""
+        # A proxy reporting slot state is demonstrably alive; clear the
+        # unavailability latch so a long-lived device that was marked
+        # unavailable is not permanently poisoned for slot waiters.
+        self._unavailable = False
         _LOGGER.debug(
             "%s [%s]: BLE connection limits: used=%s free=%s limit=%s allocated=%s",
             self.name,

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -110,7 +110,22 @@ class ESPHomeBluetoothDevice:
         # are the cross proxy duplicate symptom this work exists to kill.
         # The free and limit counters stay, zeroing free would turn the
         # public disconnect() slot wait into an immediate TimeoutError.
+        had_allocations = bool(self.ble_allocations)
         self.ble_allocations = []
+        if had_allocations and (
+            connection_slots_callback := self._connection_slots_callback
+        ):
+            # Push the cleared snapshot so the subscriber's stored copy
+            # (habluetooth's allocations map) does not keep rendering the
+            # dead session's addresses either.
+            connection_slots_callback(
+                Allocations(
+                    self.mac_address,
+                    self.ble_connections_limit,
+                    self.ble_connections_free,
+                    [],
+                )
+            )
         message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
             # Skip futures already done (a cancelled waiter leaves its

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -105,6 +105,12 @@ class ESPHomeBluetoothDevice:
         # first connect; only an explicit unavailability marks the proxy
         # dead for the wait entry guard below.
         self._unavailable = True
+        # The dead session's allocated list must not survive into a
+        # reused device; stale addresses feeding scanner.get_allocations
+        # are the cross proxy duplicate symptom this work exists to kill.
+        # The free and limit counters stay, zeroing free would turn the
+        # public disconnect() slot wait into an immediate TimeoutError.
+        self.ble_allocations = []
         message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
             # Skip futures already done (a cancelled waiter leaves its

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -31,6 +31,7 @@ class ESPHomeBluetoothDevice:
     loop: asyncio.AbstractEventLoop = field(default_factory=asyncio.get_running_loop)
     available: bool = False
     cache: ESPHomeBluetoothCache = field(default_factory=ESPHomeBluetoothCache)
+    _unavailable: bool = False
     _connection_slots_callback: Callable[[Allocations], None] | None = None
     _called_callback: bool = False
     _tracked_clients: dict[int, Callable[[], None]] = field(default_factory=dict)
@@ -78,6 +79,14 @@ class ESPHomeBluetoothDevice:
         """
         if self._tracked_clients.get(address) == on_ble_disconnected:
             del self._tracked_clients[address]
+
+    def _unavailable_message(self) -> str:
+        """Return the failure text for a wait on an unavailable proxy."""
+        return (
+            f"{self.name} [{self.mac_address}]: Proxy became unavailable "
+            "while waiting for a free BLE connection slot"
+        )
+
     def async_set_unavailable(self) -> None:
         """
         Mark the proxy unavailable and fail pending slot waiters.
@@ -87,10 +96,11 @@ class ESPHomeBluetoothDevice:
         gone; failing fast lets it retry against another proxy.
         """
         self.available = False
-        message = (
-            f"{self.name} [{self.mac_address}]: Proxy disconnected "
-            "while waiting for a free BLE connection slot"
-        )
+        # Distinct from ``available``, which defaults to False before the
+        # first connect; only an explicit unavailability marks the proxy
+        # dead for the wait entry guard below.
+        self._unavailable = True
+        message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
             # Skip futures already done (a cancelled waiter leaves its
             # future in the set until its finally runs).
@@ -259,6 +269,11 @@ class ESPHomeBluetoothDevice:
                 while waiting (see ``async_set_unavailable``).
 
         """
+        if self._unavailable:
+            # Fail fast for waiters arriving after the proxy went away;
+            # they would otherwise park the full timeout on a proxy that
+            # is provably dead.
+            raise TimeoutError(self._unavailable_message())
         if self.ble_connections_free > 0:
             return self.ble_connections_free
         fut: asyncio.Future[int] = self.loop.create_future()

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -98,8 +98,10 @@ class ESPHomeBluetoothDevice:
         ``async_update_ble_connection_limits``; ``available`` is not
         restored by that, so a caller reusing this device must set it
         back to ``True`` on reconnect, which also disarms the fail fast
-        immediately. This method never raises, so teardown paths can
-        call it without guards.
+        immediately; the free count stays zero until the proxy's first
+        slot report, so the new session never trusts the dead session's
+        count. This method never raises, so teardown paths can call it
+        without guards.
         """
         self.available = False
         # Distinct from ``available``, which defaults to False before the
@@ -109,12 +111,14 @@ class ESPHomeBluetoothDevice:
         # The dead session's allocated list must not survive into a
         # reused device; stale addresses feeding scanner.get_allocations
         # are the cross proxy duplicate symptom this work exists to kill.
-        # The free and limit counters keep the last reported state:
-        # inventing counter values would lie to allocation consumers, and
-        # waits on an unavailable device are governed by the entry guard,
-        # not the free count.
+        # ``free`` is zeroed with it: a proxy whose API connection is
+        # gone provably has no usable slots, and a reusing caller that
+        # restores ``available`` must not have connects gated (or slot
+        # waits satisfied) by the dead session's count. ``limit`` keeps
+        # the last reported capacity for allocation consumers.
         had_allocations = bool(self.ble_allocations)
         self.ble_allocations = []
+        self.ble_connections_free = 0
         message = self._unavailable_message()
         for fut in self._ble_connection_free_futures:
             # Skip futures already done (a cancelled waiter leaves its

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -109,31 +109,35 @@ class ESPHomeBluetoothDevice:
         had_state = bool(self.ble_allocations) or bool(self.ble_connections_free)
         self.ble_allocations = []
         self.ble_connections_free = 0
-        message = self._unavailable_message()
-        for fut in self._ble_connection_free_futures:
-            # A cancelled waiter can leave a done future in the set.
-            if not fut.done():
-                fut.set_exception(TimeoutError(message))
-        self._ble_connection_free_futures.clear()
-        if had_state and (connection_slots_callback := self._connection_slots_callback):
-            # Push after the waiters are failed; guarded since it ends
-            # in consumer supplied code.
-            try:
-                connection_slots_callback(
-                    Allocations(
-                        self.mac_address,
-                        self.ble_connections_limit,
-                        self.ble_connections_free,
-                        [],
-                    )
-                )
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception(
-                    "%s [%s]: Error pushing cleared allocations; the"
-                    " subscriber may keep the dead session's snapshot",
-                    self.name,
-                    self.mac_address,
-                )
+        if futures := self._ble_connection_free_futures:
+            message = self._unavailable_message()
+            for fut in futures:
+                # A cancelled waiter can leave a done future in the set.
+                if not fut.done():
+                    fut.set_exception(TimeoutError(message))
+            futures.clear()
+        if had_state:
+            # Push after the waiters are failed.
+            self._async_publish_allocations(self.ble_connections_limit, 0, [])
+
+    def _async_publish_allocations(
+        self, limit: int, free: int, allocated: list[str]
+    ) -> None:
+        """Push an allocation snapshot to the subscriber, guarded."""
+        if (connection_slots_callback := self._connection_slots_callback) is None:
+            return
+        try:
+            connection_slots_callback(
+                Allocations(self.mac_address, limit, free, allocated)
+            )
+        except Exception:  # pylint: disable=broad-except
+            # Consumer supplied code; the subscriber may keep a stale
+            # snapshot until the next push.
+            _LOGGER.exception(
+                "%s [%s]: Error pushing allocations",
+                self.name,
+                self.mac_address,
+            )
 
     def async_update_ble_connection_limits(
         self, free: int, limit: int, allocated: list[int]
@@ -172,17 +176,12 @@ class ESPHomeBluetoothDevice:
         # published allocation snapshot and the clients' connected state
         # are always consistent with each other.
         self._async_reconcile_connections()
-        if (changed or not self._called_callback) and (
-            connection_slots_callback := self._connection_slots_callback
-        ):
+        if (changed or not self._called_callback) and self._connection_slots_callback:
             self._called_callback = True
-            connection_slots_callback(
-                Allocations(
-                    self.mac_address,
-                    limit,
-                    free,
-                    [int_to_bluetooth_address(address) for address in allocated],
-                )
+            self._async_publish_allocations(
+                limit,
+                free,
+                [int_to_bluetooth_address(address) for address in allocated],
             )
 
     def _async_reconcile_connections(self) -> None:

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -129,7 +129,8 @@ class ESPHomeBluetoothDevice:
                 )
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception(
-                    "%s [%s]: Error pushing cleared allocations",
+                    "%s [%s]: Error pushing cleared allocations; the"
+                    " subscriber may keep the dead session's snapshot",
                     self.name,
                     self.mac_address,
                 )

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -116,7 +116,7 @@ class ESPHomeBluetoothDevice:
         # restores ``available`` must not have connects gated (or slot
         # waits satisfied) by the dead session's count. ``limit`` keeps
         # the last reported capacity for allocation consumers.
-        had_allocations = bool(self.ble_allocations)
+        had_state = bool(self.ble_allocations) or bool(self.ble_connections_free)
         self.ble_allocations = []
         self.ble_connections_free = 0
         message = self._unavailable_message()
@@ -126,9 +126,7 @@ class ESPHomeBluetoothDevice:
             if not fut.done():
                 fut.set_exception(TimeoutError(message))
         self._ble_connection_free_futures.clear()
-        if had_allocations and (
-            connection_slots_callback := self._connection_slots_callback
-        ):
+        if had_state and (connection_slots_callback := self._connection_slots_callback):
             # Push the cleared snapshot after the primary contract is
             # done so a raising subscriber cannot strand the waiters;
             # guarded because it ends in consumer supplied code.

--- a/src/bleak_esphome/backend/device.py
+++ b/src/bleak_esphome/backend/device.py
@@ -122,10 +122,10 @@ class ESPHomeBluetoothDevice:
 
     def _async_publish_allocations(
         self, limit: int, free: int, allocated: list[str]
-    ) -> None:
-        """Push an allocation snapshot to the subscriber, guarded."""
+    ) -> bool:
+        """Push an allocation snapshot to the subscriber; True if it landed."""
         if (connection_slots_callback := self._connection_slots_callback) is None:
-            return
+            return False
         try:
             connection_slots_callback(
                 Allocations(self.mac_address, limit, free, allocated)
@@ -138,6 +138,8 @@ class ESPHomeBluetoothDevice:
                 self.name,
                 self.mac_address,
             )
+            return False
+        return True
 
     def async_update_ble_connection_limits(
         self, free: int, limit: int, allocated: list[int]
@@ -176,13 +178,14 @@ class ESPHomeBluetoothDevice:
         # published allocation snapshot and the clients' connected state
         # are always consistent with each other.
         self._async_reconcile_connections()
-        if (changed or not self._called_callback) and self._connection_slots_callback:
+        if (changed or not self._called_callback) and self._async_publish_allocations(
+            limit,
+            free,
+            [int_to_bluetooth_address(address) for address in allocated],
+        ):
+            # Committed only when the push landed, so a raising
+            # subscriber keeps the first snapshot forced-push armed.
             self._called_callback = True
-            self._async_publish_allocations(
-                limit,
-                free,
-                [int_to_bluetooth_address(address) for address in allocated],
-            )
 
     def _async_reconcile_connections(self) -> None:
         """

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -44,13 +44,13 @@ def connect_scanner(
     The caller is responsible for:
 
     1. Calling ESPHomeClientData.scanner.async_setup()
-    2. Calling ESPHomeClientData.bluetooth_device.async_set_unavailable()
-       first when the ESP is disconnected, so the connector's can_connect
-       gate closes and slot waiters fail fast before anything else runs.
-    3. Calling ESPHomeClientData.disconnect_callbacks when the ESP is
-       disconnected.
-    4. Registering the scanner with the HA Bluetooth manager and also
+    2. Registering the scanner with the HA Bluetooth manager and also
        un-registering it when the ESP is disconnected.
+    3. Calling ESPHomeClientData.bluetooth_device.async_set_unavailable()
+       when the ESP is disconnected, before firing the callbacks, so the
+       connector's can_connect gate closes and slot waiters fail fast.
+    4. Calling ESPHomeClientData.disconnect_callbacks when the ESP is
+       disconnected.
 
     The caller may choose to override ESPHomeClientData.disconnect_callbacks
     with its own set. If it does so, it must do so before calling

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -47,9 +47,9 @@ def connect_scanner(
     2. Calling ESPHomeClientData.disconnect_callbacks when the ESP is disconnected.
     3. Registering the scanner with the HA Bluetooth manager and also
        un-registering it when the ESP is disconnected.
-    4. Setting ESPHomeClientData.bluetooth_device.available to False when the
-       ESP is disconnected, before firing the callbacks, so the connector's
-       can_connect gate stops offering the dead proxy.
+    4. Calling ESPHomeClientData.bluetooth_device.async_set_unavailable()
+       when the ESP is disconnected, before firing the callbacks, so the
+       connector's can_connect gate closes and slot waiters fail fast.
 
     The caller may choose to override ESPHomeClientData.disconnect_callbacks
     with its own set. If it does so, it must do so before calling

--- a/src/bleak_esphome/connect.py
+++ b/src/bleak_esphome/connect.py
@@ -44,12 +44,13 @@ def connect_scanner(
     The caller is responsible for:
 
     1. Calling ESPHomeClientData.scanner.async_setup()
-    2. Calling ESPHomeClientData.disconnect_callbacks when the ESP is disconnected.
-    3. Registering the scanner with the HA Bluetooth manager and also
+    2. Calling ESPHomeClientData.bluetooth_device.async_set_unavailable()
+       first when the ESP is disconnected, so the connector's can_connect
+       gate closes and slot waiters fail fast before anything else runs.
+    3. Calling ESPHomeClientData.disconnect_callbacks when the ESP is
+       disconnected.
+    4. Registering the scanner with the HA Bluetooth manager and also
        un-registering it when the ESP is disconnected.
-    4. Calling ESPHomeClientData.bluetooth_device.async_set_unavailable()
-       when the ESP is disconnected, before firing the callbacks, so the
-       connector's can_connect gate closes and slot waiters fail fast.
 
     The caller may choose to override ESPHomeClientData.disconnect_callbacks
     with its own set. If it does so, it must do so before calling

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -75,16 +75,24 @@ class APIConnectionManager:
         so connect attempts stop burning their timeout on a proxy whose
         API connection is gone.
         """
-        if self._bluetooth_device is not None:
-            self._bluetooth_device.async_set_unavailable()
+        if (bluetooth_device := self._bluetooth_device) is not None:
+            # Drop the reference first so a raising call cannot re-fire
+            # against the same dead device on the next teardown.
             self._bluetooth_device = None
+            bluetooth_device.async_set_unavailable()
 
     def _teardown_session(self) -> None:
         """Tear down the per-session client state and the scanner."""
         try:
             # async_set_unavailable never raises by contract; the guard
-            # keeps a future regression from skipping the rest anyway.
+            # keeps a future regression from skipping the rest anyway,
+            # and the log keeps the root cause visible if a later step
+            # in the finally chain also raises and replaces it as the
+            # propagating error.
             self._mark_unavailable()
+        except Exception:
+            _LOGGER.exception("%s: Error marking device unavailable", self._address)
+            raise
         finally:
             try:
                 if (disconnect_callbacks := self._disconnect_callbacks) is not None:
@@ -188,31 +196,43 @@ class APIConnectionManager:
 
     async def stop(self) -> None:
         """Stop the API connection."""
-        # Close the connect gate first so no new connection attempts are
-        # offered this proxy while its API connection is being torn down.
-        self._mark_unavailable()
         try:
-            if self._reconnect_logic is not None:
-                await self._reconnect_logic.stop()
+            # Close the connect gate first so no new connection attempts
+            # are offered this proxy while its API connection is being
+            # torn down. async_set_unavailable never raises by contract;
+            # the guard keeps a future regression from skipping the
+            # shutdown chain below, which would leave the reconnect task
+            # running and a pending start() blocked forever.
+            self._mark_unavailable()
         except Exception:
-            # A later shutdown step can replace this as the propagating
-            # error; log so the root cause is never lost. Cancellation
-            # passes through unlogged.
-            _LOGGER.exception("%s: Error stopping reconnect logic", self._address)
+            _LOGGER.exception("%s: Error marking device unavailable", self._address)
             raise
         finally:
-            # Each shutdown step runs even if the previous one raised;
-            # otherwise a failing reconnect stop would leave the API
-            # client connected and a pending start() blocked forever.
             try:
-                if self._cli is not None:
-                    await self._cli.disconnect()
+                if self._reconnect_logic is not None:
+                    await self._reconnect_logic.stop()
             except Exception:
-                _LOGGER.exception("%s: Error disconnecting API client", self._address)
+                # A later shutdown step can replace this as the propagating
+                # error; log so the root cause is never lost. Cancellation
+                # passes through unlogged.
+                _LOGGER.exception("%s: Error stopping reconnect logic", self._address)
                 raise
             finally:
-                if self._start_future is not None and not self._start_future.done():
-                    self._start_future.cancel()
-                # Same teardown as _on_disconnect so a stop() that never
-                # saw a disconnect callback still clears the session state.
-                self._teardown_session()
+                # Each shutdown step runs even if the previous one raised;
+                # otherwise a failing reconnect stop would leave the API
+                # client connected and a pending start() blocked forever.
+                try:
+                    if self._cli is not None:
+                        await self._cli.disconnect()
+                except Exception:
+                    _LOGGER.exception(
+                        "%s: Error disconnecting API client", self._address
+                    )
+                    raise
+                finally:
+                    if self._start_future is not None and not self._start_future.done():
+                        self._start_future.cancel()
+                    # Same teardown as _on_disconnect so a stop() that never
+                    # saw a disconnect callback still clears the session
+                    # state.
+                    self._teardown_session()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -68,9 +68,15 @@ class APIConnectionManager:
                 unregister()
 
     def _mark_unavailable(self) -> None:
-        """Close the connector's can_connect gate for this session's proxy."""
+        """
+        Close the connector's can_connect gate for this session's proxy.
+
+        Also fails any caller parked waiting for a free connection slot,
+        so connect attempts stop burning their timeout on a proxy whose
+        API connection is gone.
+        """
         if self._bluetooth_device is not None:
-            self._bluetooth_device.available = False
+            self._bluetooth_device.async_set_unavailable()
             self._bluetooth_device = None
 
     def _teardown_session(self) -> None:

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -73,48 +73,49 @@ class APIConnectionManager:
 
         Also fails any caller parked waiting for a free connection slot,
         so connect attempts stop burning their timeout on a proxy whose
-        API connection is gone.
+        API connection is gone. Never raises, so teardown paths need no
+        guards.
         """
-        if (bluetooth_device := self._bluetooth_device) is not None:
-            # Drop the reference first so a raising call cannot re-fire
-            # against the same dead device on the next teardown.
-            self._bluetooth_device = None
+        if (bluetooth_device := self._bluetooth_device) is None:
+            return
+        # Drop the reference first so a raising call cannot re-fire
+        # against the same dead device on the next teardown.
+        self._bluetooth_device = None
+        try:
             bluetooth_device.async_set_unavailable()
+        except Exception:  # pylint: disable=broad-except
+            # Never raises by contract; a regression must not skip the
+            # rest of the teardown.
+            _LOGGER.exception("%s: Error marking device unavailable", self._address)
+
+    def _fire_disconnect_callbacks(self) -> None:
+        """Fire and clear the per-session client disconnect callbacks."""
+        if (disconnect_callbacks := self._disconnect_callbacks) is None:
+            return
+        self._disconnect_callbacks = None
+        try:
+            # Each callback discards itself from the set, so iterate a
+            # snapshot. A callback ends in consumer supplied code; one
+            # raising must not skip the other clients.
+            for callback in list(disconnect_callbacks):
+                try:
+                    callback()
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("%s: Error in disconnect callback", self._address)
+        finally:
+            # Clear in place: clients hold a reference to this set
+            # object.
+            disconnect_callbacks.clear()
 
     def _teardown_session(self) -> None:
         """Tear down the per-session client state and the scanner."""
+        self._mark_unavailable()
         try:
-            # Never raises by contract; guard and log anyway so a later
-            # finally step cannot hide a regression here.
-            self._mark_unavailable()
-        except Exception:
-            _LOGGER.exception("%s: Error marking device unavailable", self._address)
-            raise
+            self._fire_disconnect_callbacks()
         finally:
-            try:
-                if (disconnect_callbacks := self._disconnect_callbacks) is not None:
-                    self._disconnect_callbacks = None
-                    try:
-                        # Each callback discards itself from the set, so
-                        # iterate a snapshot to avoid "set changed size
-                        # during iteration". A callback ends in consumer
-                        # supplied code; one raising must not skip the
-                        # other clients.
-                        for callback in list(disconnect_callbacks):
-                            try:
-                                callback()
-                            except Exception:  # pylint: disable=broad-except
-                                _LOGGER.exception(
-                                    "%s: Error in disconnect callback", self._address
-                                )
-                    finally:
-                        # Clear in place: clients hold a reference to this
-                        # set object.
-                        disconnect_callbacks.clear()
-            finally:
-                # The scanner unregister must run regardless; skipping it
-                # would leak the registration in habluetooth's manager.
-                self._teardown_scanner()
+            # The scanner unregister must run regardless; skipping it
+            # would leak the registration in habluetooth's manager.
+            self._teardown_scanner()
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Handle the disconnection of the API client."""
@@ -193,40 +194,31 @@ class APIConnectionManager:
 
     async def stop(self) -> None:
         """Stop the API connection."""
+        # Close the connect gate first so no new connection attempts are
+        # offered this proxy while its API connection is being torn down.
+        self._mark_unavailable()
         try:
-            # Close the connect gate first. Never raises by contract;
-            # the guard keeps a regression from skipping the shutdown
-            # chain below.
-            self._mark_unavailable()
+            if self._reconnect_logic is not None:
+                await self._reconnect_logic.stop()
         except Exception:
-            _LOGGER.exception("%s: Error marking device unavailable", self._address)
+            # A later shutdown step can replace this as the propagating
+            # error; log so the root cause is never lost. Cancellation
+            # passes through unlogged.
+            _LOGGER.exception("%s: Error stopping reconnect logic", self._address)
             raise
         finally:
+            # Each shutdown step runs even if the previous one raised;
+            # otherwise a failing reconnect stop would leave the API
+            # client connected and a pending start() blocked forever.
             try:
-                if self._reconnect_logic is not None:
-                    await self._reconnect_logic.stop()
+                if self._cli is not None:
+                    await self._cli.disconnect()
             except Exception:
-                # A later shutdown step can replace this as the propagating
-                # error; log so the root cause is never lost. Cancellation
-                # passes through unlogged.
-                _LOGGER.exception("%s: Error stopping reconnect logic", self._address)
+                _LOGGER.exception("%s: Error disconnecting API client", self._address)
                 raise
             finally:
-                # Each shutdown step runs even if the previous one raised;
-                # otherwise a failing reconnect stop would leave the API
-                # client connected and a pending start() blocked forever.
-                try:
-                    if self._cli is not None:
-                        await self._cli.disconnect()
-                except Exception:
-                    _LOGGER.exception(
-                        "%s: Error disconnecting API client", self._address
-                    )
-                    raise
-                finally:
-                    if self._start_future is not None and not self._start_future.done():
-                        self._start_future.cancel()
-                    # Same teardown as _on_disconnect so a stop() that never
-                    # saw a disconnect callback still clears the session
-                    # state.
-                    self._teardown_session()
+                if self._start_future is not None and not self._start_future.done():
+                    self._start_future.cancel()
+                # Same teardown as _on_disconnect so a stop() that never
+                # saw a disconnect callback still clears the session state.
+                self._teardown_session()

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -81,30 +81,35 @@ class APIConnectionManager:
 
     def _teardown_session(self) -> None:
         """Tear down the per-session client state and the scanner."""
-        self._mark_unavailable()
         try:
-            if (disconnect_callbacks := self._disconnect_callbacks) is not None:
-                self._disconnect_callbacks = None
-                try:
-                    # Each callback discards itself from the set, so iterate
-                    # a snapshot to avoid "set changed size during
-                    # iteration". A callback ends in consumer supplied code;
-                    # one raising must not skip the other clients.
-                    for callback in list(disconnect_callbacks):
-                        try:
-                            callback()
-                        except Exception:  # pylint: disable=broad-except
-                            _LOGGER.exception(
-                                "%s: Error in disconnect callback", self._address
-                            )
-                finally:
-                    # Clear in place: clients hold a reference to this set
-                    # object.
-                    disconnect_callbacks.clear()
+            # async_set_unavailable never raises by contract; the guard
+            # keeps a future regression from skipping the rest anyway.
+            self._mark_unavailable()
         finally:
-            # The scanner unregister must run regardless; skipping it would
-            # leak the registration in habluetooth's manager.
-            self._teardown_scanner()
+            try:
+                if (disconnect_callbacks := self._disconnect_callbacks) is not None:
+                    self._disconnect_callbacks = None
+                    try:
+                        # Each callback discards itself from the set, so
+                        # iterate a snapshot to avoid "set changed size
+                        # during iteration". A callback ends in consumer
+                        # supplied code; one raising must not skip the
+                        # other clients.
+                        for callback in list(disconnect_callbacks):
+                            try:
+                                callback()
+                            except Exception:  # pylint: disable=broad-except
+                                _LOGGER.exception(
+                                    "%s: Error in disconnect callback", self._address
+                                )
+                    finally:
+                        # Clear in place: clients hold a reference to this
+                        # set object.
+                        disconnect_callbacks.clear()
+            finally:
+                # The scanner unregister must run regardless; skipping it
+                # would leak the registration in habluetooth's manager.
+                self._teardown_scanner()
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Handle the disconnection of the API client."""

--- a/src/bleak_esphome/connection_manager.py
+++ b/src/bleak_esphome/connection_manager.py
@@ -84,11 +84,8 @@ class APIConnectionManager:
     def _teardown_session(self) -> None:
         """Tear down the per-session client state and the scanner."""
         try:
-            # async_set_unavailable never raises by contract; the guard
-            # keeps a future regression from skipping the rest anyway,
-            # and the log keeps the root cause visible if a later step
-            # in the finally chain also raises and replaces it as the
-            # propagating error.
+            # Never raises by contract; guard and log anyway so a later
+            # finally step cannot hide a regression here.
             self._mark_unavailable()
         except Exception:
             _LOGGER.exception("%s: Error marking device unavailable", self._address)
@@ -197,12 +194,9 @@ class APIConnectionManager:
     async def stop(self) -> None:
         """Stop the API connection."""
         try:
-            # Close the connect gate first so no new connection attempts
-            # are offered this proxy while its API connection is being
-            # torn down. async_set_unavailable never raises by contract;
-            # the guard keeps a future regression from skipping the
-            # shutdown chain below, which would leave the reconnect task
-            # running and a pending start() blocked forever.
+            # Close the connect gate first. Never raises by contract;
+            # the guard keeps a regression from skipping the shutdown
+            # chain below.
             self._mark_unavailable()
         except Exception:
             _LOGGER.exception("%s: Error marking device unavailable", self._address)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -663,9 +663,7 @@ async def test_bleak_client_connect_settle_runs_with_scanning_resumed(
 
     with (
         patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
-        patch.object(
-            client, "_settle_slot_after_failure", side_effect=_record_scanning
-        ),
+        patch.object(client, "_settle_slot", side_effect=_record_scanning),
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 1)
@@ -691,7 +689,7 @@ async def test_bleak_client_connect_failed_release_skips_settle(
         patch_connect_rpcs(
             client, disconnect_side_effect=APIConnectionError("api gone")
         ) as (mock_connect, _mock_disconnect),
-        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+        patch.object(client, "_settle_slot") as mock_settle,
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 1)
@@ -758,7 +756,7 @@ async def test_bleak_client_connect_services_drop_skips_settle(
             client._client,
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
-        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+        patch.object(client, "_settle_slot") as mock_settle,
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)
@@ -1455,7 +1453,7 @@ async def test_bleak_client_connect_get_services_signal_releases_without_settle(
             client._client,
             "bluetooth_device_disconnect_no_wait",
         ) as mock_disconnect,
-        patch.object(client, "_settle_slot_after_failure") as mock_settle,
+        patch.object(client, "_settle_slot") as mock_settle,
     ):
         task, callback = await start_connect(bleak_client, mock_connect)
         callback(True, 23, 0)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -375,6 +375,22 @@ async def test_bleak_client_connect(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_disconnect_completes_on_unavailable_device(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+) -> None:
+    """Disconnect completes when the proxy went unavailable mid teardown."""
+    _bleak_client, client = bleak_pair
+    client._bluetooth_device.available = True
+    client._bluetooth_device.async_set_unavailable()
+    with patch.object(
+        client._client,
+        "bluetooth_device_disconnect",
+    ) as mock_disconnect:
+        await client.disconnect()
+    mock_disconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_bleak_client_reconciled_when_missing_from_allocations(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -377,17 +377,23 @@ async def test_bleak_client_connect(
 @pytest.mark.asyncio
 async def test_bleak_client_disconnect_completes_on_unavailable_device(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Disconnect completes when the proxy went unavailable mid teardown."""
     _bleak_client, client = bleak_pair
     client._bluetooth_device.available = True
     client._bluetooth_device.async_set_unavailable()
-    with patch.object(
-        client._client,
-        "bluetooth_device_disconnect",
-    ) as mock_disconnect:
+    with (
+        caplog.at_level(logging.DEBUG),
+        patch.object(
+            client._client,
+            "bluetooth_device_disconnect",
+        ) as mock_disconnect,
+    ):
         await client.disconnect()
     mock_disconnect.assert_called_once()
+    # The swallowed settle timeout stays observable.
+    assert "Slot did not settle after disconnect" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -658,7 +658,7 @@ async def test_bleak_client_connect_settle_runs_with_scanning_resumed(
     bleak_client, client = bleak_pair
     scanning_during_settle: list[bool] = []
 
-    async def _record_scanning(context: str) -> None:
+    async def _record_scanning(*args: Any, **kwargs: Any) -> None:
         scanning_during_settle.append(client._scanner.scanning)
 
     with (

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -196,6 +196,9 @@ async def test_untrack_client_only_removes_matching_handler(
     new_handler.reset_mock()
     bluetooth_device.async_update_ble_connection_limits(3, 3, [])
     new_handler.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_fails_pending_slot_waiters(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
@@ -220,6 +223,18 @@ async def test_wait_after_unavailable_fails_fast(
     with pytest.raises(TimeoutError, match="Proxy became unavailable"):
         await bluetooth_device.wait_for_ble_connections_free(60.0)
     assert bluetooth_device._ble_connection_free_futures == set()
+
+
+@pytest.mark.asyncio
+async def test_slot_update_clears_the_unavailability_latch(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """A proxy reporting slot state again clears the fail fast latch."""
+    bluetooth_device.async_set_unavailable()
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
+        await bluetooth_device.wait_for_ble_connections_free(60.0)
+    bluetooth_device.async_update_ble_connection_limits(2, 3, [42])
+    assert await bluetooth_device.wait_for_ble_connections_free(60.0) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -228,6 +228,26 @@ async def test_set_unavailable_fails_pending_slot_waiters(
 
 
 @pytest.mark.asyncio
+async def test_set_unavailable_publishes_zeroed_free_for_idle_proxy(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    An idle proxy dying still publishes its zeroed free count.
+
+    With no allocations to clear, the free count is the only cleared
+    fact; the push must still fire so the subscriber's cached snapshot
+    does not keep advertising free slots on a dead proxy.
+    """
+    bluetooth_device.available = True
+    bluetooth_device.async_update_ble_connection_limits(3, 3, [])
+    pushed: list[Allocations] = []
+    bluetooth_device.async_subscribe_connection_slots(pushed.append)
+    bluetooth_device.async_set_unavailable()
+    assert pushed[-1].free == 0
+    assert pushed[-1].allocated == []
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_raising_subscriber_does_not_strand_waiters(
     bluetooth_device: ESPHomeBluetoothDevice,
     caplog: pytest.LogCaptureFixture,

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -228,6 +228,22 @@ async def test_set_unavailable_fails_pending_slot_waiters(
 
 
 @pytest.mark.asyncio
+async def test_update_isolates_raising_subscriber(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising slot subscriber must not abort a slot report."""
+    bluetooth_device.async_subscribe_connection_slots(
+        Mock(side_effect=ValueError("subscriber boom"))
+    )
+    with caplog.at_level(logging.ERROR):
+        bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+    # The report itself still landed.
+    assert bluetooth_device.ble_connections_free == 1
+    assert "Error pushing allocations" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_publishes_zeroed_free_for_idle_proxy(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:
@@ -274,7 +290,7 @@ async def test_set_unavailable_raising_subscriber_does_not_strand_waiters(
     with pytest.raises(TimeoutError, match="Proxy became unavailable"):
         await task
     assert bluetooth_device.ble_allocations == []
-    assert "Error pushing cleared allocations" in caplog.text
+    assert "Error pushing allocations" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -238,6 +238,26 @@ async def test_slot_update_clears_the_unavailability_latch(
 
 
 @pytest.mark.asyncio
+async def test_restoring_available_disarms_the_fail_fast(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    A reuser restoring ``available`` disarms the fail fast immediately.
+
+    The latch itself only clears on the next slot report, but a caller
+    that marked the device available again must not have its waiters
+    failed by the stale latch in the meantime.
+    """
+    bluetooth_device.async_set_unavailable()
+    bluetooth_device.available = True
+    task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+    assert await task == 1
+
+
+@pytest.mark.asyncio
 async def test_saturated_slot_update_clears_the_unavailability_latch(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -218,11 +218,13 @@ async def test_set_unavailable_fails_pending_slot_waiters(
         await task
     assert bluetooth_device.available is False
     assert bluetooth_device._ble_connection_free_futures == set()
-    # The dead session's allocated list must not survive into a reuse,
-    # and the cleared snapshot is pushed so the subscriber's stored copy
-    # does not keep the stale addresses either.
+    # The dead session's allocated list and free count must not survive
+    # into a reuse, and the cleared snapshot is pushed so the
+    # subscriber's stored copy does not keep the stale state either.
     assert bluetooth_device.ble_allocations == []
+    assert bluetooth_device.ble_connections_free == 0
     assert pushed[-1].allocated == []
+    assert pushed[-1].free == 0
 
 
 @pytest.mark.asyncio
@@ -276,6 +278,31 @@ async def test_slot_update_clears_the_unavailability_latch(
         await bluetooth_device.wait_for_ble_connections_free(60.0)
     bluetooth_device.async_update_ble_connection_limits(2, 3, [42])
     assert await bluetooth_device.wait_for_ble_connections_free(60.0) == 2
+
+
+@pytest.mark.asyncio
+async def test_reuse_after_unavailable_does_not_trust_stale_free_count(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    A reused device must not serve the dead session's free count.
+
+    ``async_set_unavailable`` zeroes ``ble_connections_free``, so a
+    caller that restores ``available`` on reconnect parks for the new
+    session's first slot report instead of getting an immediate return
+    from a count the dead session left behind.
+    """
+    bluetooth_device.available = True
+    bluetooth_device.async_update_ble_connection_limits(2, 3, [42])
+    bluetooth_device.async_set_unavailable()
+    assert bluetooth_device.ble_connections_free == 0
+    assert bluetooth_device.ble_connections_limit == 3
+    bluetooth_device.available = True
+    task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [43])
+    assert await task == 1
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -212,6 +212,8 @@ async def test_set_unavailable_fails_pending_slot_waiters(
         await task
     assert bluetooth_device.available is False
     assert bluetooth_device._ble_connection_free_futures == set()
+    # The dead session's allocated list must not survive into a reuse.
+    assert bluetooth_device.ble_allocations == []
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -196,6 +196,36 @@ async def test_untrack_client_only_removes_matching_handler(
     new_handler.reset_mock()
     bluetooth_device.async_update_ble_connection_limits(3, 3, [])
     new_handler.assert_not_called()
+async def test_set_unavailable_fails_pending_slot_waiters(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """A parked slot waiter fails fast when the proxy goes unavailable."""
+    bluetooth_device.available = True
+    task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+    bluetooth_device.async_set_unavailable()
+    with pytest.raises(TimeoutError, match="Proxy disconnected"):
+        await task
+    assert bluetooth_device.available is False
+    assert bluetooth_device._ble_connection_free_futures == set()
+
+
+@pytest.mark.asyncio
+async def test_set_unavailable_skips_done_futures(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """A done future is skipped while a pending one still fails fast."""
+    loop = asyncio.get_running_loop()
+    done_fut: asyncio.Future[int] = loop.create_future()
+    done_fut.cancel()
+    pending_fut: asyncio.Future[int] = loop.create_future()
+    bluetooth_device._ble_connection_free_futures.update({done_fut, pending_fut})
+    bluetooth_device.async_set_unavailable()
+    assert done_fut.cancelled()
+    with pytest.raises(TimeoutError, match="Proxy disconnected"):
+        await pending_fut
+    assert bluetooth_device._ble_connection_free_futures == set()
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -241,6 +241,12 @@ async def test_update_isolates_raising_subscriber(
     # The report itself still landed.
     assert bluetooth_device.ble_connections_free == 1
     assert "Error pushing allocations" in caplog.text
+    # The failed push keeps the first snapshot forced push armed: an
+    # identical update retries once the subscriber heals.
+    pushed: list[Allocations] = []
+    bluetooth_device._connection_slots_callback = pushed.append
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+    assert len(pushed) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -250,6 +250,30 @@ async def test_update_isolates_raising_subscriber(
 
 
 @pytest.mark.asyncio
+async def test_failed_cleared_push_rearms_the_forced_push(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed cleared snapshot push re-arms the forced push."""
+    bluetooth_device.available = True
+    good: list[Allocations] = []
+    bluetooth_device.async_subscribe_connection_slots(good.append)
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+    assert len(good) == 1
+    bluetooth_device._connection_slots_callback = Mock(
+        side_effect=ValueError("subscriber boom")
+    )
+    with caplog.at_level(logging.ERROR):
+        bluetooth_device.async_set_unavailable()
+    # The subscriber heals; an update matching the zeroed state still
+    # pushes because the failed clear re-armed the forced push.
+    bluetooth_device._connection_slots_callback = good.append
+    bluetooth_device.async_update_ble_connection_limits(0, 3, [])
+    assert len(good) == 2
+    assert good[-1].free == 0
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_publishes_zeroed_free_for_idle_proxy(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -274,6 +274,20 @@ async def test_failed_cleared_push_rearms_the_forced_push(
 
 
 @pytest.mark.asyncio
+async def test_set_unavailable_skips_push_when_nothing_to_clear(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """An already zeroed device pushes nothing on unavailability."""
+    pushed: list[Allocations] = []
+    bluetooth_device.async_subscribe_connection_slots(pushed.append)
+    bluetooth_device.async_set_unavailable()
+    assert pushed == []
+    # Idempotent: a second call also pushes nothing.
+    bluetooth_device.async_set_unavailable()
+    assert pushed == []
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_publishes_zeroed_free_for_idle_proxy(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -204,6 +204,12 @@ async def test_set_unavailable_fails_pending_slot_waiters(
 ) -> None:
     """A parked slot waiter fails fast when the proxy goes unavailable."""
     bluetooth_device.available = True
+    # Seed real session state so the clearing assertions below are not
+    # satisfied vacuously by the fixture's empty defaults; free stays
+    # zero so the waiter parks.
+    bluetooth_device.async_update_ble_connection_limits(0, 2, [42, 43])
+    pushed: list[Allocations] = []
+    bluetooth_device.async_subscribe_connection_slots(pushed.append)
     task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
     await asyncio.sleep(0)
     assert not task.done()
@@ -212,8 +218,11 @@ async def test_set_unavailable_fails_pending_slot_waiters(
         await task
     assert bluetooth_device.available is False
     assert bluetooth_device._ble_connection_free_futures == set()
-    # The dead session's allocated list must not survive into a reuse.
+    # The dead session's allocated list must not survive into a reuse,
+    # and the cleared snapshot is pushed so the subscriber's stored copy
+    # does not keep the stale addresses either.
     assert bluetooth_device.ble_allocations == []
+    assert pushed[-1].allocated == []
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -205,9 +205,20 @@ async def test_set_unavailable_fails_pending_slot_waiters(
     await asyncio.sleep(0)
     assert not task.done()
     bluetooth_device.async_set_unavailable()
-    with pytest.raises(TimeoutError, match="Proxy disconnected"):
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
         await task
     assert bluetooth_device.available is False
+    assert bluetooth_device._ble_connection_free_futures == set()
+
+
+@pytest.mark.asyncio
+async def test_wait_after_unavailable_fails_fast(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """A waiter entering after the proxy went away fails immediately."""
+    bluetooth_device.async_set_unavailable()
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
+        await bluetooth_device.wait_for_ble_connections_free(60.0)
     assert bluetooth_device._ble_connection_free_futures == set()
 
 
@@ -223,7 +234,7 @@ async def test_set_unavailable_skips_done_futures(
     bluetooth_device._ble_connection_free_futures.update({done_fut, pending_fut})
     bluetooth_device.async_set_unavailable()
     assert done_fut.cancelled()
-    with pytest.raises(TimeoutError, match="Proxy disconnected"):
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
         await pending_fut
     assert bluetooth_device._ble_connection_free_futures == set()
 

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -226,6 +226,36 @@ async def test_set_unavailable_fails_pending_slot_waiters(
 
 
 @pytest.mark.asyncio
+async def test_set_unavailable_raising_subscriber_does_not_strand_waiters(
+    bluetooth_device: ESPHomeBluetoothDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A raising slot subscriber cannot strand the parked waiters.
+
+    The waiters are failed before the cleared snapshot push runs, and
+    the push itself is guarded because it ends in consumer supplied
+    code, so ``async_set_unavailable`` never raises.
+    """
+    bluetooth_device.available = True
+    bluetooth_device.async_update_ble_connection_limits(0, 2, [42, 43])
+    bluetooth_device.async_subscribe_connection_slots(
+        Mock(side_effect=ValueError("subscriber boom"))
+    )
+    task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    with caplog.at_level(logging.ERROR):
+        bluetooth_device.async_set_unavailable()
+
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
+        await task
+    assert bluetooth_device.ble_allocations == []
+    assert "Error pushing cleared allocations" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_wait_after_unavailable_fails_fast(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/backend/test_device.py
+++ b/tests/backend/test_device.py
@@ -238,6 +238,27 @@ async def test_slot_update_clears_the_unavailability_latch(
 
 
 @pytest.mark.asyncio
+async def test_saturated_slot_update_clears_the_unavailability_latch(
+    bluetooth_device: ESPHomeBluetoothDevice,
+) -> None:
+    """
+    A ``free=0`` slot report also clears the fail fast latch.
+
+    A saturated proxy is alive, not dead; the reset is deliberately
+    unconditional at the top of the update, so a waiter parks for a slot
+    instead of failing fast.
+    """
+    bluetooth_device.async_set_unavailable()
+    bluetooth_device.async_update_ble_connection_limits(0, 3, [])
+    task = asyncio.create_task(bluetooth_device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    # The waiter parks rather than raising immediately.
+    assert not task.done()
+    bluetooth_device.async_update_ble_connection_limits(1, 3, [42])
+    assert await task == 1
+
+
+@pytest.mark.asyncio
 async def test_set_unavailable_skips_done_futures(
     bluetooth_device: ESPHomeBluetoothDevice,
 ) -> None:

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -392,6 +392,22 @@ async def test_stop_tears_down_session_state(
 
 
 @pytest.mark.asyncio
+async def test_teardown_closes_gate_before_disconnect_callbacks(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """The connect gate is closed before consumer disconnect callbacks fire."""
+    device = ESPHomeBluetoothDevice("proxy", "AA:BB:CC:DD:EE:FF", available=True)
+    conn_manager._bluetooth_device = device
+    seen: list[bool] = []
+    callbacks: set[Callable[[], None]] = {lambda: seen.append(device.available)}
+    conn_manager._disconnect_callbacks = callbacks
+
+    await conn_manager._on_disconnect(expected_disconnect=False)
+
+    assert seen == [False]
+
+
+@pytest.mark.asyncio
 async def test_on_disconnect_fails_parked_slot_waiter_end_to_end(
     conn_manager: APIConnectionManager,
 ) -> None:

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -471,17 +471,16 @@ async def test_on_disconnect_isolates_raising_callback(
 
 
 @pytest.mark.asyncio
-async def test_on_disconnect_teardown_survives_raising_set_unavailable(
+async def test_teardown_survives_raising_set_unavailable(
     conn_manager: APIConnectionManager,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
-    A raising ``async_set_unavailable`` must not skip the session teardown.
+    A raising ``async_set_unavailable`` must not skip the teardown.
 
-    The method never raises by contract; the structural guard keeps a
-    future regression from skipping the disconnect callbacks and the
-    scanner unregister, and the failure is logged so a later teardown
-    step raising cannot erase the root cause.
+    The method never raises by contract; the guard at the choke point
+    contains a regression, logs it, and lets the disconnect callbacks
+    and the scanner unregister proceed.
     """
     bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     bluetooth_device.async_set_unavailable.side_effect = RuntimeError("device boom")
@@ -492,10 +491,7 @@ async def test_on_disconnect_teardown_survives_raising_set_unavailable(
     unregister = Mock()
     conn_manager._unregister_scanner = unregister
 
-    with (
-        caplog.at_level(logging.ERROR),
-        pytest.raises(RuntimeError, match="device boom"),
-    ):
+    with caplog.at_level(logging.ERROR):
         await conn_manager._on_disconnect(expected_disconnect=False)
 
     callback.assert_called_once_with()
@@ -505,44 +501,6 @@ async def test_on_disconnect_teardown_survives_raising_set_unavailable(
     # The reference was dropped before the call, so the next teardown
     # cannot re-fire against the same dead device.
     assert conn_manager._bluetooth_device is None
-
-
-@pytest.mark.asyncio
-async def test_stop_shutdown_survives_raising_set_unavailable(
-    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """
-    A raising ``async_set_unavailable`` must not skip ``stop()``'s shutdown.
-
-    ``stop()`` marks the device unavailable first; if that call raised
-    unguarded, the reconnect stop, the API client disconnect, the
-    disconnect callbacks, the scanner unregister, and the start future
-    cancel would all be skipped, leaving a pending ``start()`` blocked
-    forever.
-    """
-    manager, mock_reconnect_logic, mock_disconnect = conn_manager_with_mocked_reconnect
-    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
-    bluetooth_device.async_set_unavailable.side_effect = RuntimeError("device boom")
-    manager._bluetooth_device = bluetooth_device
-    callback = Mock()
-    callbacks: set[Callable[[], None]] = {callback}
-    manager._disconnect_callbacks = callbacks
-    unregister = Mock()
-    manager._unregister_scanner = unregister
-
-    with (
-        caplog.at_level(logging.ERROR),
-        pytest.raises(RuntimeError, match="device boom"),
-    ):
-        await manager.stop()
-
-    mock_reconnect_logic.stop.assert_awaited_once_with()
-    mock_disconnect.assert_awaited_once_with()
-    callback.assert_called_once_with()
-    assert not callbacks
-    unregister.assert_called_once_with()
-    assert "Error marking device unavailable" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -314,7 +314,7 @@ async def test_on_disconnect_marks_bluetooth_device_unavailable(
 
     await conn_manager._on_disconnect(expected_disconnect=False)
 
-    assert bluetooth_device.available is False
+    bluetooth_device.async_set_unavailable.assert_called_once_with()
     assert conn_manager._bluetooth_device is None
 
 
@@ -386,7 +386,7 @@ async def test_stop_tears_down_session_state(
     # ``cast`` re-widens the attribute type mypy narrowed after the direct
     # assignment above so the assert is not flagged unreachable.
     assert cast("set[Callable[[], None]] | None", manager._disconnect_callbacks) is None
-    assert bluetooth_device.available is False
+    bluetooth_device.async_set_unavailable.assert_called_once_with()
     assert manager._bluetooth_device is None
 
 
@@ -447,10 +447,10 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     manager._bluetooth_device = bluetooth_device
     unregister = Mock()
     manager._unregister_scanner = unregister
-    seen_available: list[bool] = []
+    gate_closed_first: list[bool] = []
 
     async def _stop_and_raise() -> None:
-        seen_available.append(bluetooth_device.available)
+        gate_closed_first.append(bluetooth_device.async_set_unavailable.called)
         raise RuntimeError("stop boom")
 
     mock_reconnect_logic.stop = AsyncMock(side_effect=_stop_and_raise)
@@ -465,7 +465,7 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     assert "Error stopping reconnect logic" in caplog.text
 
     # The gate was already closed when the first shutdown await ran.
-    assert seen_available == [False]
+    assert gate_closed_first == [True]
     unregister.assert_called_once_with()
     # ``cast`` re-widens the attribute type mypy narrowed after the direct
     # assignment above so the following statements are not unreachable.
@@ -513,10 +513,11 @@ async def test_stop_after_disconnect_does_not_refire_callbacks(
 
     await manager._on_disconnect(expected_disconnect=True)
     callback.assert_called_once_with()
-    assert bluetooth_device.available is False
+    bluetooth_device.async_set_unavailable.assert_called_once_with()
 
     await manager.stop()
     callback.assert_called_once_with()
+    bluetooth_device.async_set_unavailable.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -455,6 +455,34 @@ async def test_on_disconnect_isolates_raising_callback(
 
 
 @pytest.mark.asyncio
+async def test_on_disconnect_teardown_survives_raising_set_unavailable(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """
+    A raising ``async_set_unavailable`` must not skip the session teardown.
+
+    The method never raises by contract; the structural guard keeps a
+    future regression from skipping the disconnect callbacks and the
+    scanner unregister.
+    """
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
+    bluetooth_device.async_set_unavailable.side_effect = RuntimeError("device boom")
+    conn_manager._bluetooth_device = bluetooth_device
+    callback = Mock()
+    callbacks: set[Callable[[], None]] = {callback}
+    conn_manager._disconnect_callbacks = callbacks
+    unregister = Mock()
+    conn_manager._unregister_scanner = unregister
+
+    with pytest.raises(RuntimeError, match="device boom"):
+        await conn_manager._on_disconnect(expected_disconnect=False)
+
+    callback.assert_called_once_with()
+    assert not callbacks
+    unregister.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 import pytest_asyncio
 
+from bleak_esphome.backend.device import ESPHomeBluetoothDevice
 from bleak_esphome.connection_manager import (
     APIConnectionManager,
     ESPHomeDeviceConfig,
@@ -309,7 +310,7 @@ async def test_on_disconnect_marks_bluetooth_device_unavailable(
     The connector's ``can_connect`` gate reads ``available``; leaving it
     set would keep offering a proxy whose API connection is gone.
     """
-    bluetooth_device = Mock(available=True)
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     conn_manager._bluetooth_device = bluetooth_device
 
     await conn_manager._on_disconnect(expected_disconnect=False)
@@ -376,7 +377,7 @@ async def test_stop_tears_down_session_state(
     callback = Mock()
     callbacks: set[Callable[[], None]] = {callback}
     manager._disconnect_callbacks = callbacks
-    bluetooth_device = Mock(available=True)
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     manager._bluetooth_device = bluetooth_device
 
     await manager.stop()
@@ -388,6 +389,29 @@ async def test_stop_tears_down_session_state(
     assert cast("set[Callable[[], None]] | None", manager._disconnect_callbacks) is None
     bluetooth_device.async_set_unavailable.assert_called_once_with()
     assert manager._bluetooth_device is None
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_fails_parked_slot_waiter_end_to_end(
+    conn_manager: APIConnectionManager,
+) -> None:
+    """
+    A real parked slot waiter fails fast when the manager tears down.
+
+    Uses a real ``ESPHomeBluetoothDevice`` rather than a mock so the
+    manager to device wiring is proven end to end.
+    """
+    device = ESPHomeBluetoothDevice("proxy", "AA:BB:CC:DD:EE:FF", available=True)
+    conn_manager._bluetooth_device = device
+    task = asyncio.create_task(device.wait_for_ble_connections_free(60.0))
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    await conn_manager._on_disconnect(expected_disconnect=False)
+
+    with pytest.raises(TimeoutError, match="Proxy became unavailable"):
+        await task
+    assert device.available is False
 
 
 @pytest.mark.asyncio
@@ -443,7 +467,7 @@ async def test_stop_marks_unavailable_first_and_tears_down_on_error(
     even if a shutdown await raises.
     """
     manager, mock_reconnect_logic, mock_disconnect = conn_manager_with_mocked_reconnect
-    bluetooth_device = Mock(available=True)
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     manager._bluetooth_device = bluetooth_device
     unregister = Mock()
     manager._unregister_scanner = unregister
@@ -508,7 +532,7 @@ async def test_stop_after_disconnect_does_not_refire_callbacks(
     manager, _, _ = conn_manager_with_mocked_reconnect
     callback = Mock()
     manager._disconnect_callbacks = {callback}
-    bluetooth_device = Mock(available=True)
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     manager._bluetooth_device = bluetooth_device
 
     await manager._on_disconnect(expected_disconnect=True)

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -457,13 +457,15 @@ async def test_on_disconnect_isolates_raising_callback(
 @pytest.mark.asyncio
 async def test_on_disconnect_teardown_survives_raising_set_unavailable(
     conn_manager: APIConnectionManager,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     A raising ``async_set_unavailable`` must not skip the session teardown.
 
     The method never raises by contract; the structural guard keeps a
     future regression from skipping the disconnect callbacks and the
-    scanner unregister.
+    scanner unregister, and the failure is logged so a later teardown
+    step raising cannot erase the root cause.
     """
     bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
     bluetooth_device.async_set_unavailable.side_effect = RuntimeError("device boom")
@@ -474,12 +476,57 @@ async def test_on_disconnect_teardown_survives_raising_set_unavailable(
     unregister = Mock()
     conn_manager._unregister_scanner = unregister
 
-    with pytest.raises(RuntimeError, match="device boom"):
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(RuntimeError, match="device boom"),
+    ):
         await conn_manager._on_disconnect(expected_disconnect=False)
 
     callback.assert_called_once_with()
     assert not callbacks
     unregister.assert_called_once_with()
+    assert "Error marking device unavailable" in caplog.text
+    # The reference was dropped before the call, so the next teardown
+    # cannot re-fire against the same dead device.
+    assert conn_manager._bluetooth_device is None
+
+
+@pytest.mark.asyncio
+async def test_stop_shutdown_survives_raising_set_unavailable(
+    conn_manager_with_mocked_reconnect: tuple[APIConnectionManager, Mock, AsyncMock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A raising ``async_set_unavailable`` must not skip ``stop()``'s shutdown.
+
+    ``stop()`` marks the device unavailable first; if that call raised
+    unguarded, the reconnect stop, the API client disconnect, the
+    disconnect callbacks, the scanner unregister, and the start future
+    cancel would all be skipped, leaving a pending ``start()`` blocked
+    forever.
+    """
+    manager, mock_reconnect_logic, mock_disconnect = conn_manager_with_mocked_reconnect
+    bluetooth_device = Mock(spec=ESPHomeBluetoothDevice, available=True)
+    bluetooth_device.async_set_unavailable.side_effect = RuntimeError("device boom")
+    manager._bluetooth_device = bluetooth_device
+    callback = Mock()
+    callbacks: set[Callable[[], None]] = {callback}
+    manager._disconnect_callbacks = callbacks
+    unregister = Mock()
+    manager._unregister_scanner = unregister
+
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(RuntimeError, match="device boom"),
+    ):
+        await manager.stop()
+
+    mock_reconnect_logic.stop.assert_awaited_once_with()
+    mock_disconnect.assert_awaited_once_with()
+    callback.assert_called_once_with()
+    assert not callbacks
+    unregister.assert_called_once_with()
+    assert "Error marking device unavailable" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A caller parked in wait_for_ble_connections_free kept waiting out its full timeout even when the proxy's API connection had already dropped; nothing failed the pending slot futures, so a connect attempt sat on a proxy that is provably dead instead of failing fast and retrying against another proxy. This was flagged during review of #424 and is adjacent to the slot starvation symptoms in home-assistant/core#176516.

ESPHomeBluetoothDevice gains async_set_unavailable, which flips available and immediately fails pending slot waiters with the same TimeoutError contract the timeout path uses, naming the proxy; waiters arriving after the proxy went away fail fast via a latch, and the latch clears when the proxy reports slot state again since that is proof of life. available is not restored by the latch clear, so a caller reusing a device must set it back on reconnect. APIConnectionManager calls it from its teardown, so standalone users get this automatically.

Callers that wire connect_scanner by hand must change: on ESP disconnect, replace setting bluetooth_device.available = False with calling bluetooth_device.async_set_unavailable(), before firing the disconnect callbacks. The bare attribute flip still closes the can_connect gate but leaves parked slot waiters burning their timeout, so it is no longer sufficient. The docstring contract, docs/usage.md, and the runnable example all show the new call; Home Assistant's entry_data needs the same one line swap when it bumps to a release containing this. ESPHomeClient.disconnect() also no longer propagates the slot settle TimeoutError after a successful disconnect; the condition is logged at debug ("Slot did not settle after disconnect") instead.

> [!WARNING]
> **Breaking change for callers that wire `connect_scanner` by hand.**
> On ESP disconnect, call `client_data.bluetooth_device.async_set_unavailable()` before firing the disconnect callbacks, instead of setting `bluetooth_device.available = False`. The bare attribute flip still closes the `can_connect` gate but leaves parked slot waiters burning their full timeout, so it no longer fulfills the disconnect contract. `APIConnectionManager` users are migrated automatically; Home Assistant's `entry_data` needs the same swap when it bumps to a release containing this.

BREAKING CHANGE: callers wiring connect_scanner by hand must call bluetooth_device.async_set_unavailable() on ESP disconnect, before firing the disconnect callbacks, instead of setting bluetooth_device.available = False. ESPHomeClient.disconnect() no longer raises TimeoutError when the freed slot does not settle after a successful disconnect; it logs at debug instead.


