### PR TITLE
fix: match the bluez disconnected callback contract and refuse handover of a dead link

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,6 +148,18 @@ give each proxy a clearly stronger signal for its intended device (position
 and antenna orientation), and avoid having two proxies with near-identical
 RSSI competing for the same peripheral.
 
+## When does `disconnected_callback` fire?
+
+Once per connection that `connect()` actually handed over: it fires on a
+real disconnect of that connection (device initiated, ESP initiated, or
+requested via `disconnect()`), persists across connect and disconnect
+cycles on a reused client, and never fires for a connect attempt that
+raised. A link that drops while pairing or service discovery is still
+running surfaces as the failing `connect()` instead; if the last setup
+step still resolves from cache after such a drop, `connect()` raises
+`BleakError("<device>: Disconnected during connect setup")` rather than
+returning a client on a dead link.
+
 ## My `disconnected_callback` fired without a disconnect event in the logs
 
 A connected client can be torn down by allocation reconciliation, without a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,8 +156,8 @@ running, matching bleak's bluez backend for device initiated drops; the
 callback persists across connect and disconnect cycles on a reused
 client. Unlike bluez, library side abandonment of a failed attempt is
 silent, because the consumer never received the client; it surfaces
-through the raising `connect()` alone. If the link drops during setup but service
-discovery still resolves from cache, `connect()` raises
+through the raising `connect()` alone. If the link drops during setup but the
+discovery response still resolves, `connect()` raises
 `BleakError("<device>: Disconnected during connect setup")` rather than
 returning a client on a dead link.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,9 +155,10 @@ up, including a drop while pairing or service discovery is still
 running, matching bleak's bluez backend for device initiated drops; the
 callback persists across connect and disconnect cycles on a reused
 client. A `disconnect()` you requested also fires it, and so does the
-reconciliation teardown described below. Unlike bluez, library side abandonment of a failed attempt is
-silent, because the consumer never received the client; it surfaces
-through the raising `connect()` alone. If the link drops during setup but the
+reconciliation teardown described below. Unlike bluez, library side
+abandonment of a failed attempt is silent, because the consumer never
+received the client; it surfaces through the raising `connect()` alone.
+If the link drops during setup but the
 discovery response still resolves, `connect()` raises
 `BleakError("<device>: Disconnected during connect setup")` rather than
 returning a client on a dead link.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -150,13 +150,13 @@ RSSI competing for the same peripheral.
 
 ## When does `disconnected_callback` fire?
 
-Once per connection that `connect()` actually handed over: it fires on a
-real disconnect of that connection (device initiated, ESP initiated, or
-requested via `disconnect()`), persists across connect and disconnect
-cycles on a reused client, and never fires for a connect attempt that
-raised. A link that drops while pairing or service discovery is still
-running surfaces as the failing `connect()` instead; if the last setup
-step still resolves from cache after such a drop, `connect()` raises
+Whenever the proxy reports the link down for a connection that had come
+up, including a drop while pairing or service discovery is still
+running, matching bleak's bluez backend; the callback persists across
+connect and disconnect cycles on a reused client. Library side
+abandonment of a failed attempt is silent and surfaces through the
+raising `connect()` alone. If the link drops during setup but service
+discovery still resolves from cache, `connect()` raises
 `BleakError("<device>: Disconnected during connect setup")` rather than
 returning a client on a dead link.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,7 +154,8 @@ Whenever the proxy reports the link down for a connection that had come
 up, including a drop while pairing or service discovery is still
 running, matching bleak's bluez backend for device initiated drops; the
 callback persists across connect and disconnect cycles on a reused
-client. Unlike bluez, library side abandonment of a failed attempt is
+client. A `disconnect()` you requested also fires it, and so does the
+reconciliation teardown described below. Unlike bluez, library side abandonment of a failed attempt is
 silent, because the consumer never received the client; it surfaces
 through the raising `connect()` alone. If the link drops during setup but the
 discovery response still resolves, `connect()` raises

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,10 +152,11 @@ RSSI competing for the same peripheral.
 
 Whenever the proxy reports the link down for a connection that had come
 up, including a drop while pairing or service discovery is still
-running, matching bleak's bluez backend; the callback persists across
-connect and disconnect cycles on a reused client. Library side
-abandonment of a failed attempt is silent and surfaces through the
-raising `connect()` alone. If the link drops during setup but service
+running, matching bleak's bluez backend for device initiated drops; the
+callback persists across connect and disconnect cycles on a reused
+client. Unlike bluez, library side abandonment of a failed attempt is
+silent, because the consumer never received the client; it surfaces
+through the raising `connect()` alone. If the link drops during setup but service
 discovery still resolves from cache, `connect()` raises
 `BleakError("<device>: Disconnected during connect setup")` rather than
 returning a client on a dead link.

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -221,10 +221,15 @@ class ESPHomeClient(BaseBleakClient):
         self._async_ble_device_disconnected()
 
     def _async_call_bleak_disconnected_callback(self) -> None:
-        """Call the disconnected callback to inform the bleak consumer."""
+        """
+        Call the disconnected callback to inform the bleak consumer.
+
+        The callback persists for the client's next connection, matching
+        the other bleak backends; once per connection is guaranteed by
+        the handover gate, which cleanup clears before this runs.
+        """
         if self._disconnected_callback:
             self._disconnected_callback()
-            self._disconnected_callback = None
 
     def _raise_if_spurious_cancellation(self) -> None:
         """

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -529,9 +529,9 @@ class ESPHomeClient(BaseBleakClient):
             self._abandon_connect_attempt()
             raise
         if not self._is_connected:
-            # The link dropped during setup but the last step still
-            # returned (cached services); hand over nothing. No settle:
-            # the drop already ran cleanup, so nothing was released.
+            # The link dropped during setup but service discovery still
+            # resolved; hand over nothing. No settle: the drop already
+            # ran cleanup, so nothing was released.
             self._abandon_connect_attempt()
             raise BleakError(f"{self._description}: Disconnected during connect setup")
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -206,7 +206,7 @@ class ESPHomeClient(BaseBleakClient):
         # Notify the consumer only for a connection connect() handed
         # over; a drop during setup is surfaced by the failing connect,
         # and notifying would also null the callback for the retry.
-        notify = self._is_connected and self._connect_completed
+        notify = self._connect_completed
         self._async_disconnected_cleanup()
         if notify:
             _LOGGER.debug("%s: BLE device disconnected", self._description)
@@ -528,6 +528,11 @@ class ESPHomeClient(BaseBleakClient):
             # No settle on cancels and signals; still release.
             self._abandon_connect_attempt()
             raise
+        if not self._is_connected:
+            # The link dropped during setup but the last step still
+            # returned (cached services); hand over nothing.
+            self._abandon_connect_attempt()
+            raise BleakError(f"{self._description}: Disconnected during connect setup")
         # The connection is now the consumer's; a later drop notifies
         # its disconnected_callback.
         self._connect_completed = True

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -293,7 +293,7 @@ class ESPHomeClient(BaseBleakClient):
                 exc_info=True,
             )
         # No consumer notification: an abandoned attempt must not fire
-        # (and null) ``disconnected_callback``.
+        # ``disconnected_callback`` for a client the consumer never got.
         self._async_disconnected_cleanup()
         return sent
 

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -160,6 +160,7 @@ class ESPHomeClient(BaseBleakClient):
         self._client = client_data.client
         self._is_connected = False
         self._pending_release = False
+        self._connect_completed = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
         self._notify_cancels: dict[
@@ -188,6 +189,7 @@ class ESPHomeClient(BaseBleakClient):
         self.services = BleakGATTServiceCollection()
         self._is_connected = False
         self._pending_release = False
+        self._connect_completed = False
         for _, notify_abort in self._notify_cancels.values():
             notify_abort()
         self._notify_cancels.clear()
@@ -201,9 +203,12 @@ class ESPHomeClient(BaseBleakClient):
 
     def _async_ble_device_disconnected(self) -> None:
         """Handle the BLE device disconnecting from the ESP."""
-        was_connected = self._is_connected
+        # Notify the consumer only for a connection connect() handed
+        # over; a drop during setup is surfaced by the failing connect,
+        # and notifying would also null the callback for the retry.
+        notify = self._is_connected and self._connect_completed
         self._async_disconnected_cleanup()
-        if was_connected:
+        if notify:
             _LOGGER.debug("%s: BLE device disconnected", self._description)
             self._async_call_bleak_disconnected_callback()
 
@@ -523,6 +528,9 @@ class ESPHomeClient(BaseBleakClient):
             # No settle on cancels and signals; still release.
             self._abandon_connect_attempt()
             raise
+        # The connection is now the consumer's; a later drop notifies
+        # its disconnected_callback.
+        self._connect_completed = True
 
     @api_error_as_bleak_error
     async def disconnect(self) -> None:

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -535,7 +535,8 @@ class ESPHomeClient(BaseBleakClient):
             raise
         if not self._is_connected:
             # The link dropped during setup but the last step still
-            # returned (cached services); hand over nothing.
+            # returned (cached services); hand over nothing. No settle:
+            # the drop already ran cleanup, so nothing was released.
             self._abandon_connect_attempt()
             raise BleakError(f"{self._description}: Disconnected during connect setup")
         # The connection is now the consumer's; a later drop notifies

--- a/src/bleak_esphome/backend/client.py
+++ b/src/bleak_esphome/backend/client.py
@@ -160,7 +160,6 @@ class ESPHomeClient(BaseBleakClient):
         self._client = client_data.client
         self._is_connected = False
         self._pending_release = False
-        self._connect_completed = False
         self._mtu: int | None = None
         self._cancel_connection_state: Callable[[], None] | None = None
         self._notify_cancels: dict[
@@ -189,7 +188,6 @@ class ESPHomeClient(BaseBleakClient):
         self.services = BleakGATTServiceCollection()
         self._is_connected = False
         self._pending_release = False
-        self._connect_completed = False
         for _, notify_abort in self._notify_cancels.values():
             notify_abort()
         self._notify_cancels.clear()
@@ -203,12 +201,9 @@ class ESPHomeClient(BaseBleakClient):
 
     def _async_ble_device_disconnected(self) -> None:
         """Handle the BLE device disconnecting from the ESP."""
-        # Notify the consumer only for a connection connect() handed
-        # over; a drop during setup is surfaced by the failing connect,
-        # and notifying would also null the callback for the retry.
-        notify = self._connect_completed
+        was_connected = self._is_connected
         self._async_disconnected_cleanup()
-        if notify:
+        if was_connected:
             _LOGGER.debug("%s: BLE device disconnected", self._description)
             self._async_call_bleak_disconnected_callback()
 
@@ -224,9 +219,9 @@ class ESPHomeClient(BaseBleakClient):
         """
         Call the disconnected callback to inform the bleak consumer.
 
-        The callback persists for the client's next connection, matching
-        the other bleak backends; once per connection is guaranteed by
-        the handover gate, which cleanup clears before this runs.
+        The callback persists for the client's next connection and fires
+        on every link down of a connection that came up, matching the
+        bluez backend.
         """
         if self._disconnected_callback:
             self._disconnected_callback()
@@ -539,9 +534,6 @@ class ESPHomeClient(BaseBleakClient):
             # the drop already ran cleanup, so nothing was released.
             self._abandon_connect_attempt()
             raise BleakError(f"{self._description}: Disconnected during connect setup")
-        # The connection is now the consumer's; a later drop notifies
-        # its disconnected_callback.
-        self._connect_completed = True
 
     @api_error_as_bleak_error
     async def disconnect(self) -> None:

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -770,13 +770,19 @@ async def test_bleak_client_disconnected_callback_fires_every_cycle(
             "bluetooth_gatt_get_services",
             return_value=esphome_bluetooth_gatt_services,
         ),
+        patch.object(client._client, "bluetooth_device_disconnect"),
     ):
         for cycle in (1, 2):
             task, callback = await start_connect(bleak_client, mock_connect)
             callback(True, 23, 0)
             await task
             assert client.is_connected
-            callback(False, 23, 0)
+            if cycle == 1:
+                # Proxy reported drop.
+                callback(False, 23, 0)
+            else:
+                # A requested disconnect notifies too, as in bluez.
+                await bleak_client.disconnect()
             assert disconnected_callback.call_count == cycle
 
 

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -782,24 +782,29 @@ async def test_bleak_client_disconnected_callback_fires_every_cycle(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "failure_shape", ["error_code", "pair", "services", "drop", "drop_cache_return"]
+    ("failure_shape", "drop_notifies"),
+    [
+        ("error_code", False),
+        ("pair", False),
+        ("services", False),
+        ("drop", True),
+        ("drop_cache_return", True),
+    ],
 )
 async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
     failure_shape: str,
+    drop_notifies: bool,
 ) -> None:
     """
-    Test abandonment is silent to the consumer and the callback survives.
+    Test the callback survives every failed attempt shape.
 
-    An abandoned attempt never handed the consumer a connected client, so
-    it must not fire ``disconnected_callback`` and must not null it; the
-    retry connector reuses one client instance, and a later successful
-    connect still has to deliver the real disconnect notification. Pinned
-    for every abandonment shape: a connect error after link up, a failed
-    pairing, a failed service discovery, and a device initiated drop
-    during discovery, whether or not the services still resolve from
-    cache afterwards.
+    Library side abandonment (a connect error, a failed pairing, a
+    failed service discovery) is silent; a device initiated drop
+    notifies exactly like the bluez backend. Either way the callback is
+    never cleared, so the retry connector reusing one client instance
+    still delivers the later real disconnect notification.
     """
     bleak_client, client = bleak_pair
     disconnected_callback = Mock()
@@ -852,7 +857,7 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
             callback(True, 23, 1 if failure_shape == "error_code" else 0)
             with pytest.raises(BleakError):
                 await task
-            disconnected_callback.assert_not_called()
+            assert disconnected_callback.call_count == (1 if drop_notifies else 0)
             assert client._disconnected_callback is disconnected_callback
 
         # Attempt 2 succeeds on the same instance.
@@ -861,9 +866,9 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
         await task
         assert client.is_connected
 
-        # The real disconnect still notifies the consumer exactly once.
+        # The real disconnect still notifies the consumer.
         callback(False, 23, 0)
-        disconnected_callback.assert_called_once_with()
+        assert disconnected_callback.call_count == (2 if drop_notifies else 1)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -601,7 +601,7 @@ async def test_bleak_client_connect_cancel_racing_link_up_then_drop(
 
     The abandoned attempt never handed the connection to the caller, so
     a ``connected=False`` racing in before the task resumes must not
-    fire (or null) the consumer's disconnected_callback, and the
+    fire the consumer's disconnected_callback, and the
     abandonment has nothing left to release because the ESP already
     dropped the link.
     """
@@ -822,7 +822,7 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
         return Mock()
 
     with (
-        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
+        patch_connect_rpcs(client) as (mock_connect, mock_disconnect),
         patch.object(
             client._client,
             "bluetooth_gatt_get_services",
@@ -864,6 +864,9 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
                 await task
             assert disconnected_callback.call_count == (1 if drop_notifies else 0)
             assert client._disconnected_callback is disconnected_callback
+            if drop_notifies:
+                # The drop already ran cleanup, so nothing is released.
+                mock_disconnect.assert_not_called()
 
         # Attempt 2 succeeds on the same instance.
         task, callback = await start_connect(bleak_client, mock_connect)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -749,7 +749,7 @@ async def test_bleak_client_connect_services_drop_skips_settle(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure_shape", ["error_code", "pair", "services"])
+@pytest.mark.parametrize("failure_shape", ["error_code", "pair", "services", "drop"])
 async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
@@ -763,11 +763,17 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     retry connector reuses one client instance, and a later successful
     connect still has to deliver the real disconnect notification. Pinned
     for every abandonment shape: a connect error after link up, a failed
-    pairing, and a failed service discovery.
+    pairing, a failed service discovery, and a device initiated drop
+    during discovery.
     """
     bleak_client, client = bleak_pair
     disconnected_callback = Mock()
     client._disconnected_callback = disconnected_callback
+
+    async def _drop_during_services(*args: Any, **kwargs: Any) -> Any:
+        # Device initiated drop mid discovery, then the op fails.
+        client._async_ble_device_disconnected()
+        raise BleakError("dropped during discovery")
 
     with (
         patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
@@ -796,6 +802,12 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
                 failure_stack.enter_context(
                     patch.object(
                         client, "_get_services", side_effect=_boom_get_services
+                    )
+                )
+            if failure_shape == "drop":
+                failure_stack.enter_context(
+                    patch.object(
+                        client, "_get_services", side_effect=_drop_during_services
                     )
                 )
             # Attempt 1 fails; the consumer never saw a connected client.

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -855,7 +855,12 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
             # Attempt 1 fails; the consumer never saw a connected client.
             task, callback = await start_connect(client, mock_connect, pair=pair)
             callback(True, 23, 1 if failure_shape == "error_code" else 0)
-            with pytest.raises(BleakError):
+            raises_kwargs = (
+                {"match": "Disconnected during connect setup"}
+                if failure_shape == "drop_cache_return"
+                else {}
+            )
+            with pytest.raises(BleakError, **raises_kwargs):
                 await task
             assert disconnected_callback.call_count == (1 if drop_notifies else 0)
             assert client._disconnected_callback is disconnected_callback

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -749,7 +749,9 @@ async def test_bleak_client_connect_services_drop_skips_settle(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure_shape", ["error_code", "pair", "services", "drop"])
+@pytest.mark.parametrize(
+    "failure_shape", ["error_code", "pair", "services", "drop", "drop_cache_return"]
+)
 async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     bleak_pair: tuple[BleakClient, ESPHomeClient],
     esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
@@ -764,7 +766,8 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
     connect still has to deliver the real disconnect notification. Pinned
     for every abandonment shape: a connect error after link up, a failed
     pairing, a failed service discovery, and a device initiated drop
-    during discovery.
+    during discovery, whether or not the services still resolve from
+    cache afterwards.
     """
     bleak_client, client = bleak_pair
     disconnected_callback = Mock()
@@ -774,6 +777,12 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
         # Device initiated drop mid discovery, then the op fails.
         client._async_ble_device_disconnected()
         raise BleakError("dropped during discovery")
+
+    async def _drop_then_cached_services(*args: Any, **kwargs: Any) -> Any:
+        # Device initiated drop mid discovery, but the services still
+        # resolve (cache); connect() must not hand over the dead link.
+        client._async_ble_device_disconnected()
+        return Mock()
 
     with (
         patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
@@ -798,17 +807,13 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
                         ),
                     )
                 )
-            if failure_shape == "services":
+            if side_effect := {
+                "services": _boom_get_services,
+                "drop": _drop_during_services,
+                "drop_cache_return": _drop_then_cached_services,
+            }.get(failure_shape):
                 failure_stack.enter_context(
-                    patch.object(
-                        client, "_get_services", side_effect=_boom_get_services
-                    )
-                )
-            if failure_shape == "drop":
-                failure_stack.enter_context(
-                    patch.object(
-                        client, "_get_services", side_effect=_drop_during_services
-                    )
+                    patch.object(client, "_get_services", side_effect=side_effect)
                 )
             # Attempt 1 fails; the consumer never saw a connected client.
             task, callback = await start_connect(client, mock_connect, pair=pair)

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -749,6 +749,38 @@ async def test_bleak_client_connect_services_drop_skips_settle(
 
 
 @pytest.mark.asyncio
+async def test_bleak_client_disconnected_callback_fires_every_cycle(
+    bleak_pair: tuple[BleakClient, ESPHomeClient],
+    esphome_bluetooth_gatt_services: ESPHomeBluetoothGATTServices,
+) -> None:
+    """
+    The callback persists and fires on every owned disconnect.
+
+    bleak backends never null the disconnected callback; a client
+    instance reused across connect and disconnect cycles must notify on
+    each one.
+    """
+    bleak_client, client = bleak_pair
+    disconnected_callback = Mock()
+    client._disconnected_callback = disconnected_callback
+    with (
+        patch_connect_rpcs(client) as (mock_connect, _mock_disconnect),
+        patch.object(
+            client._client,
+            "bluetooth_gatt_get_services",
+            return_value=esphome_bluetooth_gatt_services,
+        ),
+    ):
+        for cycle in (1, 2):
+            task, callback = await start_connect(bleak_client, mock_connect)
+            callback(True, 23, 0)
+            await task
+            assert client.is_connected
+            callback(False, 23, 0)
+            assert disconnected_callback.call_count == cycle
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "failure_shape", ["error_code", "pair", "services", "drop", "drop_cache_return"]
 )

--- a/tests/backend/test_client.py
+++ b/tests/backend/test_client.py
@@ -788,7 +788,7 @@ async def test_bleak_client_disconnected_callback_fires_every_cycle(
         ("pair", False),
         ("services", False),
         ("drop", True),
-        ("drop_cache_return", True),
+        ("drop_resolved", True),
     ],
 )
 async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
@@ -815,11 +815,11 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
         client._async_ble_device_disconnected()
         raise BleakError("dropped during discovery")
 
-    async def _drop_then_cached_services(*args: Any, **kwargs: Any) -> Any:
-        # Device initiated drop mid discovery, but the services still
-        # resolve (cache); connect() must not hand over the dead link.
+    async def _drop_then_resolved_services(*args: Any, **kwargs: Any) -> Any:
+        # Device initiated drop while the discovery RPC is in flight;
+        # the response still resolves.
         client._async_ble_device_disconnected()
-        return Mock()
+        return esphome_bluetooth_gatt_services
 
     with (
         patch_connect_rpcs(client) as (mock_connect, mock_disconnect),
@@ -847,20 +847,29 @@ async def test_bleak_client_abandoned_attempt_preserves_disconnected_callback(
             if side_effect := {
                 "services": _boom_get_services,
                 "drop": _drop_during_services,
-                "drop_cache_return": _drop_then_cached_services,
             }.get(failure_shape):
                 failure_stack.enter_context(
                     patch.object(client, "_get_services", side_effect=side_effect)
                 )
+            if failure_shape == "drop_resolved":
+                # Drive the real _get_services so its entry guard and
+                # the post-drop resolution are both exercised.
+                failure_stack.enter_context(
+                    patch.object(
+                        client._client,
+                        "bluetooth_gatt_get_services",
+                        side_effect=_drop_then_resolved_services,
+                    )
+                )
             # Attempt 1 fails; the consumer never saw a connected client.
             task, callback = await start_connect(client, mock_connect, pair=pair)
             callback(True, 23, 1 if failure_shape == "error_code" else 0)
-            raises_kwargs = (
-                {"match": "Disconnected during connect setup"}
-                if failure_shape == "drop_cache_return"
-                else {}
+            match = (
+                "Disconnected during connect setup"
+                if failure_shape == "drop_resolved"
+                else None
             )
-            with pytest.raises(BleakError, **raises_kwargs):
+            with pytest.raises(BleakError, match=match):
                 await task
             assert disconnected_callback.call_count == (1 if drop_notifies else 0)
             assert client._disconnected_callback is disconnected_callback

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -263,6 +263,7 @@ async def test_esp_disconnected_invokes_bleak_callback(
     """The ESP-side disconnect callback fires the bleak disconnect callback once."""
     client = _make_client(client_data)
     client._is_connected = True
+    client._connect_completed = True
     callback = Mock()
     client._disconnected_callback = callback
     client._async_esp_disconnected()
@@ -277,6 +278,7 @@ async def test_esp_disconnected_does_not_refire_callback(
     """A second ESP disconnect after the callback cleared is a no-op."""
     client = _make_client(client_data)
     client._is_connected = True
+    client._connect_completed = True
     callback = Mock()
     client._disconnected_callback = callback
     client._async_esp_disconnected()
@@ -284,6 +286,7 @@ async def test_esp_disconnected_does_not_refire_callback(
     # Simulate a stale second disconnect: the callback was cleared, and any
     # subsequent disconnect must not refire it.
     client._is_connected = True
+    client._connect_completed = True
     client._async_esp_disconnected()
     callback.assert_called_once()
 

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -275,7 +275,7 @@ async def test_esp_disconnected_invokes_bleak_callback(
 async def test_esp_disconnected_does_not_refire_callback(
     client_data: ESPHomeClientData,
 ) -> None:
-    """A second ESP disconnect after the callback cleared is a no-op."""
+    """A second ESP disconnect with no new link up is a no-op."""
     client = _make_client(client_data)
     client._is_connected = True
     callback = Mock()

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -284,8 +284,9 @@ async def test_esp_disconnected_does_not_refire_callback(
     client._disconnected_callback = callback
     client._async_esp_disconnected()
     callback.assert_called_once()
-    # A stale second disconnect must not refire: cleanup cleared the
-    # handover flag, so the gate stays closed until the next connect.
+    # A stale re-entry of the old gate variable must not reopen the
+    # gate; only connect() handing over sets _connect_completed again.
+    client._is_connected = True
     client._async_esp_disconnected()
     callback.assert_called_once()
 

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -268,7 +268,8 @@ async def test_esp_disconnected_invokes_bleak_callback(
     client._disconnected_callback = callback
     client._async_esp_disconnected()
     callback.assert_called_once()
-    assert client._disconnected_callback is None
+    # bleak parity: the callback persists for the next connection.
+    assert client._disconnected_callback is callback
 
 
 @pytest.mark.asyncio
@@ -283,13 +284,10 @@ async def test_esp_disconnected_does_not_refire_callback(
     client._disconnected_callback = callback
     client._async_esp_disconnected()
     callback.assert_called_once()
-    # Simulate a stale second disconnect: the callback was cleared, and any
-    # subsequent disconnect must not refire it.
-    client._is_connected = True
-    client._connect_completed = True
+    # A stale second disconnect must not refire: cleanup cleared the
+    # handover flag, so the gate stays closed until the next connect.
     client._async_esp_disconnected()
     callback.assert_called_once()
-    assert client._disconnected_callback is None
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -263,7 +263,6 @@ async def test_esp_disconnected_invokes_bleak_callback(
     """The ESP-side disconnect callback fires the bleak disconnect callback once."""
     client = _make_client(client_data)
     client._is_connected = True
-    client._connect_completed = True
     callback = Mock()
     client._disconnected_callback = callback
     client._async_esp_disconnected()
@@ -279,14 +278,13 @@ async def test_esp_disconnected_does_not_refire_callback(
     """A second ESP disconnect after the callback cleared is a no-op."""
     client = _make_client(client_data)
     client._is_connected = True
-    client._connect_completed = True
     callback = Mock()
     client._disconnected_callback = callback
     client._async_esp_disconnected()
     callback.assert_called_once()
-    # A stale re-entry of the old gate variable must not reopen the
-    # gate; only connect() handing over sets _connect_completed again.
-    client._is_connected = True
+    # A stale second disconnect is silent: cleanup cleared the link
+    # state, so there is no transition to report. A genuine second link
+    # up then down fires again, as in bluez.
     client._async_esp_disconnected()
     callback.assert_called_once()
 

--- a/tests/backend/test_client_branches.py
+++ b/tests/backend/test_client_branches.py
@@ -289,6 +289,7 @@ async def test_esp_disconnected_does_not_refire_callback(
     client._connect_completed = True
     client._async_esp_disconnected()
     callback.assert_called_once()
+    assert client._disconnected_callback is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #422 for the deferred pre-existing shape. The bug was the fire once clearing of disconnected_callback, not the firing: a device initiated drop while pairing or service discovery was still running fired the callback and nulled it for good, so with bleak_retry_connector reusing one client instance, the retry's later real disconnect notified nobody.

The fix is parity with bleak's bluez client. bleak.backends.bluezdbus keeps disconnected_callback for the life of the client and fires it on every link down of a connection that came up, including a drop during setup, never clearing it after one call; that spurious looking mid setup fire is harmless there precisely because the callback survives. This backend now does the same: the clearing is removed, a drop during setup still notifies exactly as bluez does, and the callback persists so a reused client notifies on every owned disconnect.

The one practically observable change is that connect() now refuses to hand over a dead link: if the link drops during setup but the discovery response still resolves, it raises BleakError("<device>: Disconnected during connect setup") instead of returning a client on a dead link that can never notify.

Behavior was verified scenario by scenario against bleak.backends.bluezdbus: a drop after link up notifies, an attempt that never reached link up stays silent, a requested disconnect notifies, a reused client notifies on every cycle, cleanup runs before the notify so the callback observes a disconnected client, and a stale duplicate disconnect with no new transition is a no op. Each scenario is pinned by a test.
